### PR TITLE
Simplify the instruction for installing this package

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,14 @@ A Python toolkit for managing, retrieving, and processing data.
 ## Installation
 You can install the toolkit with:
 ```bash
-$ poetry add git+https://github.com/dataware-tools/pydtk.git
+$ pip3 install git+https://github.com/dataware-tools/pydtk.git
 
 ```
 
-Make sure that [poetry](https://python-poetry.org/) is installed before executing the command.
-
-If you want to install the toolkit with extra feature (e.g. support for mysql DB), 
-please specify it with `-E` option.  
-Example (installation with `mysql` and `ros` extras):
+If you want to install the toolkit with extra feature (e.g. support for mysql DB and ROS), 
+you can install extra dependencies as follows:
 ```bash
-$ poetry add git+https://github.com/dataware-tools/pydtk.git -E mysql -E ros
+$ pip3 install git+https://github.com/dataware-tools/pydtk.git#egg=pydtk[mysql,ros]
 
 ```
 
@@ -85,3 +82,12 @@ $ poetry install
 
 ```
 
+Make sure that [poetry](https://python-poetry.org/) is installed before executing the command.
+
+If you want to install the toolkit with extra feature (e.g. support for mysql DB), 
+please specify it with `-E` option.  
+Example (installation with `mysql` and `ros` extras):
+```bash
+$ poetry install -E mysql -E ros
+
+```

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -30,17 +30,14 @@ You can install the toolkit with the following command:
 
 .. code-block:: bash
 
-   $ poetry add git+https://github.com/dataware-tools/pydtk.git
+   $ pip3 install git+https://github.com/dataware-tools/pydtk.git
 
-Make sure that `poetry <https://python-poetry.org/>`_ is installed before executing the command.
-
-If you want to install the toolkit with extra feature (e.g. support for mysql DB),
-please specify it with `-E` option.
-Example (installation with `mysql` and `ros` extras):
+If you want to install the toolkit with extra feature (e.g. support for mysql DB and ROS),
+you can install extra dependencies as follows:
 
 .. code-block:: bash
 
-   $ poetry add git+https://github.com/dataware-tools/pydtk.git -E mysql -E ros
+   $ pip3 install git+https://github.com/dataware-tools/pydtk.git#egg=pydtk[mysql,ros]
 
 
 


### PR DESCRIPTION
## What?
Use `pip` instead of `poetry` to install this package in README.

## Why?
`pip` is more popular with installing Python packages.