### PR TITLE
fix DBHandler to allow empty password

### DIFF
--- a/pydtk/db/v2/handlers/__init__.py
+++ b/pydtk/db/v2/handlers/__init__.py
@@ -155,7 +155,7 @@ class BaseDBHandler(object):
                 else 'mysql' if engine == 'mariadb' \
                 else engine
             username_and_password = '' \
-                if any([username == '', password == '']) \
+                if all([username == '', password == '']) \
                 else '{0}:{1}@'.format(username, password)
             self._engine = sqlalchemy.create_engine(
                 '{0}://{1}{2}{3}'.format(


### PR DESCRIPTION
## What?
- fix DBHandler not to use default username and password when only pasword is empty

## Why?
- to use easily when pydtk user want to create username(or role) that have empty pasword