### PR TITLE
add io.errors

### DIFF
--- a/pydtk/io/__init__.py
+++ b/pydtk/io/__init__.py
@@ -7,3 +7,4 @@
 
 from pydtk.io.writer import BaseFileWriter
 from pydtk.io.reader import BaseFileReader
+from pydtk.io.errors import NoModelMatchedError

--- a/pydtk/io/errors.py
+++ b/pydtk/io/errors.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright Toolkit Authors
+
+"""pydtk modules."""
+
+
+class NoModelMatchedError(BaseException):
+    """Error of module matching."""
+
+    pass

--- a/pydtk/io/reader.py
+++ b/pydtk/io/reader.py
@@ -11,12 +11,7 @@ import os
 
 from pydtk.models import MODELS_BY_PRIORITY, MetaDataModel
 from pydtk.preprocesses import PassThrough
-
-
-class NoModelMatchedError(BaseException):
-    """Error of module matching."""
-
-    pass
+from pydtk.io.errors import NoModelMatchedError
 
 
 class BaseFileReader(metaclass=ABCMeta):

--- a/pydtk/io/writer.py
+++ b/pydtk/io/writer.py
@@ -9,12 +9,7 @@ from abc import ABCMeta
 
 from pydtk.models import MODELS_BY_PRIORITY, MetaDataModel
 from pydtk.preprocesses import PassThrough
-
-
-class NoModelMatchedError(BaseException):
-    """Error of module matching."""
-
-    pass
+from pydtk.io.errors import NoModelMatchedError
 
 
 class BaseFileWriter(metaclass=ABCMeta):


### PR DESCRIPTION
## What?
- add io.errors

## Why?
- in examples/02_grab_data_based_on_metadata.ipynb, NoModelMatcedError is imported from pydtk.io.