### PR TITLE
Add `content_type` to the index columns of meta_df

### DIFF
--- a/pydtk/conf/v3.yaml
+++ b/pydtk/conf/v3.yaml
@@ -85,6 +85,7 @@ meta_df:
     - record_id
     - sub_record_id
     - contents
+    - content_type
   content_columns:
     - msg_type
     - msg_md5sum


### PR DESCRIPTION
## What?
Use `content_type` as an additional column to index meta_df

## Why?
To handle files with different content-type but the same content-name
