### PR TITLE
fix bug that "creation_time_in_df" in DBHandler.df duplicate after falilure of DBHandler.read() 

### DIFF
--- a/pydtk/db/v3/handlers/__init__.py
+++ b/pydtk/db/v3/handlers/__init__.py
@@ -197,7 +197,7 @@ class BaseDBHandler(_V2BaseDBHandler):
         """Initialize DF."""
         df = pd.concat(
             [pd.Series(name=c['name'],
-                       dtype=dtype_string_to_dtype_object(c['dtype'])) for c in self.columns]
+                       dtype=dtype_string_to_dtype_object(c['dtype'])) for c in self.columns if c['name'] != 'uuid_in_df' and c['name'] != 'creation_time_in_df']  # noqa: E501
             + [pd.Series(name='uuid_in_df', dtype=str),
                pd.Series(name='creation_time_in_df', dtype=float)],
             axis=1


### PR DESCRIPTION
## What?
- `DBHandler.read()` が正しく実行された後に `DBHandler.read()` が失敗すると，`DBHandler.df` 内の `creation_time_in_df` が重複するバグの修正

## Why?
- バグ修正

## バグの詳細
1. `DBHandler.df` の `setter` 内で `DBHandler.columns` もセットされるため，`DBHandler.read()` が成功すると `DBHandler.columns` に `uuid_in_df` と `creation_time_in_df` が含まれるようになる
2. この状態で `DBHandler.read()` が失敗すると，`DBHandler._initialize_df()` の結果が `df.setter` に与えられる
3. `DBHandler._initialize_df()` は `DBHandler.columns` が何であろうと それに `uuid_in_df` と `creation_time_in_df` を加えて返すため，`DBHandler.df` 内の  `creation_time_in_df` が重複する．`uuid_id_df` は ` df.set_index('uuid_in_df', inplace=True)` で消える
4. この状態で `DBHandler.add_data()` を実行すると，その内部の `pandas.concat` で `ValueError: Plan shapes are not aligned` が発生する


## バグ再現の手順
```
$ docker exec -it pydtk python3
>>> from pydtk.db import V3DBHandler as DBHandler
>>> handler = DBHandler(db_class='meta', db_engine='sqlite', db_host='test/test_v3.db', base_dir_path='test', read_on_init=False)
>>> handler.df
Empty DataFrame
Columns: [description, database_id, record_id, sub_record_id, data_type, path, start_timestamp, end_timestamp, content_type, contents, msg_type, msg_md5sum, count, frequency, tags, creation_time_in_df]
Index: []
>>> handler.read(limit=1)
>>> handler.df
                                       description                database_id                 record_id sub_record_id data_type  ...                        msg_md5sum  count  frequency          tags creation_time_in_df
uuid_in_df                                                                                                                       ...                                                                                      
62e0659fbbb3449cde9b42446d680c97  Driving Database  Driving Behavior Database  B05_17000000010000000829          None  raw_data  ...  2d3a8cd499b9b4a0249fb98fd05cfa48      1       None  vehicle;gnss        1.612312e+09

[1 rows x 16 columns]
>>> handler.read(where="aaaa")
Could not execute SQL statement: "SELECT * 
FROM db_0ffc6dbe_meta 
WHERE aaaa" (reason: (sqlite3.OperationalError) no such column: aaaa
[SQL: SELECT count(*) 
FROM db_0ffc6dbe_meta 
WHERE aaaa]
(Background on this error at: http://sqlalche.me/e/13/e3q8))
>>> handler.df
Empty DataFrame
Columns: [description, database_id, record_id, sub_record_id, data_type, path, start_timestamp, end_timestamp, content_type, contents, msg_type, msg_md5sum, count, frequency, tags, creation_time_in_df, creation_time_in_df]
Index: []
```
