### PR TITLE
Fix the behavior of V4DBHandler on `add_data`

### DIFF
--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -469,7 +469,22 @@ class BaseDBHandler(object):
                 base_data = self._data[data['_uuid']]
                 data = self._merger.merge(base_data, data)
 
-        # TODO: Add column (key) to config
+        # Add new columns (keys) to config
+        columns = self._config['columns'] if 'columns' in self._config.keys() else []
+        columns_existing = [c['name'] for c in columns]
+        columns_in_data = list(data_in.keys())
+        new_columns = []
+        for new_column in set(columns_in_data).difference(columns_existing):
+            name = new_column
+            dtype = type(data_in[new_column]).__name__
+            aggregation = 'first'
+            new_columns.append({
+                'name': name,
+                'dtype': dtype,
+                'aggregation': aggregation
+            })
+        columns += new_columns
+        self._config['columns'] = columns
 
         self._data.update({data['_uuid']: data})
 

--- a/pydtk/utils/utils.py
+++ b/pydtk/utils/utils.py
@@ -19,6 +19,10 @@ DTYPE_MAP = {
     'float': float,
     'double': float,
     'boolean': bool,
+    'bool': bool,
+    'obj': object,
+    'object': object,
+    'dict': object,
     'none': None
 }
 

--- a/test/test_db_v4.py
+++ b/test/test_db_v4.py
@@ -578,6 +578,56 @@ def test_group_by_mongo(
         assert len(grouped) == len(set(all[key])), 'AssertionError: group_key: {}'.format(key)
 
 
+@pytest.mark.parametrize(db_args, db_list)
+def test_add_columns(
+    db_engine: str,
+    db_host: str,
+    db_username: Optional[str],
+    db_password: Optional[str]
+):
+    """Add columns to DB.
+
+    Args:
+        db_engine (str): DB engine (e.g., 'tinydb')
+        db_host (str): Host of path of DB
+        db_username (str): Username
+        db_password (str): Password
+
+    """
+    handler = V4DBHandler(
+        db_class='meta',
+        db_engine=db_engine,
+        db_host=db_host,
+        db_username=db_username,
+        db_password=db_password,
+        base_dir_path='/opt/pydtk/test',
+        orient='contents'
+    )
+    assert isinstance(handler, V4MetaDBHandler)
+    data = {
+        'key-int': int(0),
+        'key-float': float(0.0),
+        'key-str': 'str',
+        'key-dict': {
+            'abc': 'def'
+        }
+    }
+    handler.add_data(data)
+    for key in ['key-int', 'key-float', 'key-str', 'key-dict']:
+        assert key in [c['name'] for c in handler.config['columns']]
+        assert next(filter(lambda c: c['name'] == key, handler.config['columns']))['dtype'] \
+               == type(data[key]).__name__
+    handler.save()
+
+    handler.read()
+    for key in ['key-int', 'key-float', 'key-str', 'key-dict']:
+        assert key in [c['name'] for c in handler.config['columns']]
+        assert next(filter(lambda c: c['name'] == key, handler.config['columns']))['dtype'] \
+               == type(data[key]).__name__
+    handler.remove_data(data)
+    handler.save()
+
+
 if __name__ == '__main__':
     test_create_db(*default_db_parameter)
     test_load_db(*default_db_parameter)

--- a/test/test_db_v4.py
+++ b/test/test_db_v4.py
@@ -616,14 +616,14 @@ def test_add_columns(
     for key in ['key-int', 'key-float', 'key-str', 'key-dict']:
         assert key in [c['name'] for c in handler.config['columns']]
         assert next(filter(lambda c: c['name'] == key, handler.config['columns']))['dtype'] \
-               == type(data[key]).__name__
+               == type(data[key]).__name__  # noqa: E721
     handler.save()
 
     handler.read()
     for key in ['key-int', 'key-float', 'key-str', 'key-dict']:
         assert key in [c['name'] for c in handler.config['columns']]
         assert next(filter(lambda c: c['name'] == key, handler.config['columns']))['dtype'] \
-               == type(data[key]).__name__
+               == type(data[key]).__name__  # noqa: E721
     handler.remove_data(data)
     handler.save()
 


### PR DESCRIPTION
## What?
Fix the bug that new columns (keys) were not added to configs when new data was added

## Why?
Bug fix