### PR TITLE
Add CI to publish to PyPI on release

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -2,7 +2,12 @@ name: CI
 on:
   push:
     branches:
-      - feature/ci-release-pypi
+      - feature/ci-release-pypi-0.0.0
+
+#on:
+#  push:
+#    tags:
+#      - 'v*.*.*'
 
 jobs:
   publish:
@@ -12,7 +17,8 @@ jobs:
 #        python-version: [3.6, 3.7, 3.8, 3.9]
         python-version: [3.7]
         poetry-version: [1.1.2]
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+#        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -23,6 +29,13 @@ jobs:
         uses: abatilo/actions-poetry@v2.0.0
         with:
           poetry-version: ${{ matrix.poetry-version }}
+      - name: Fix version
+        shell: bash
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          VERSION=$(echo ${REF##*/} | sed 's/[^0-9.]//g')
+          sed -i -e 's/0.0.0/'"$VERSION"'/' pyproject.toml
       - name: Configure
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -25,7 +25,7 @@ jobs:
           poetry-version: ${{ matrix.poetry-version }}
       - name: Configure
         env:
-          PYPI_TOKEN: ${{ secret.PYPI_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: poetry config pypi-token.pypi $PYPI_TOKEN
       - name: Build
         run: poetry build

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -42,5 +42,5 @@ jobs:
         run: poetry config pypi-token.pypi $PYPI_TOKEN
       - name: Build
         run: poetry build
-#      - name: Publish
-#        run: poetry publish
+      - name: Publish
+        run: poetry publish

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -1,13 +1,8 @@
-name: CI
+name: Publish to PyPI
 on:
   push:
-    branches:
-      - feature/ci-release-pypi-0.0.0
-
-#on:
-#  push:
-#    tags:
-#      - 'v*.*.*'
+    tags:
+      - 'v*.*.*'
 
 jobs:
   publish:

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  push:
+    branches:
+      - feature/ci-release-pypi
+
+jobs:
+  publish:
+    strategy:
+      fail-fast: false
+      matrix:
+#        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7]
+        poetry-version: [1.1.2]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run image
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: ${{ matrix.poetry-version }}
+      - name: Configure
+        env:
+          PYPI_TOKEN: ${{ secret.PYPI_TOKEN }}
+        run: poetry config pypi-token.pypi $PYPI_TOKEN
+      - name: Build
+        run: poetry build
+#      - name: Publish
+#        run: poetry publish

--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -18,7 +18,7 @@ jobs:
         python-version: [3.7]
         poetry-version: [1.1.2]
 #        os: [ubuntu-18.04, macos-latest, windows-latest]
-        os: [ubuntu-18.04, macos-latest]
+        os: [ubuntu-18.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pyyaml = "*"
 pycryptodomex = { version = "*", optional = true }
 gnupg = { version = "*", optional = true }
 rospkg = { version = "*", optional = true }
-pypcd = { git = "https://github.com/klintan/pypcd.git", optional = true }
+#pypcd = { git = "https://github.com/klintan/pypcd.git", optional = true }
 pyntcloud = { version = "*", optional = true }
 attrdict = "*"
 tqdm = "^4.46.1"
@@ -45,7 +45,7 @@ sqlalchemy-migrate = "*"
 opencv-python = "^4.2.0.34"
 influxdb = { version = "^5.3.0", optional = true }
 cassandra-driver = { version = "^3.24.0", optional = true }
-pandra = { git = "https://github.com/d-hayashi/pandas-cassandra", optional = true }
+#pandra = { git = "https://github.com/d-hayashi/pandas-cassandra", optional = true }
 mysqlclient = { version = "^2.0.1", optional = true }
 bitstring = "^3.1.7"
 psycopg2-binary = { version = "^2.8.6", optional = true }
@@ -55,10 +55,10 @@ elasticsearch = { version = "^7.11.0", optional = true }
 deepmerge = "^0.1.1"
 tinymongo = "^0.2.0"
 # TODO: Avoid specifying git repository when PR `https://github.com/alonho/pql/pull/30` is merged
-pql = [
-    { git = "https://github.com/comfuture/pql.git", rev = "358c42b7aa15634268c41850a01a4ff9f5c0994f", python = ">=3.7" },
-    { version = "<=0.4.3", python = "<3.7" }
-]
+#pql = [
+#    { git = "https://github.com/comfuture/pql.git", rev = "358c42b7aa15634268c41850a01a4ff9f5c0994f", python = ">=3.7" },
+#    { version = "<=0.4.3", python = "<3.7" }
+#]
 flatten-dict = "^0.3.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pyyaml = "*"
 pycryptodomex = { version = "*", optional = true }
 gnupg = { version = "*", optional = true }
 rospkg = { version = "*", optional = true }
-#pypcd = { git = "https://github.com/klintan/pypcd.git", optional = true }
+pypcd = { git = "https://github.com/klintan/pypcd.git", optional = true }
 pyntcloud = { version = "*", optional = true }
 attrdict = "*"
 tqdm = "^4.46.1"
@@ -45,7 +45,7 @@ sqlalchemy-migrate = "*"
 opencv-python = "^4.2.0.34"
 influxdb = { version = "^5.3.0", optional = true }
 cassandra-driver = { version = "^3.24.0", optional = true }
-#pandra = { git = "https://github.com/d-hayashi/pandas-cassandra", optional = true }
+pandra = { git = "https://github.com/d-hayashi/pandas-cassandra", optional = true }
 mysqlclient = { version = "^2.0.1", optional = true }
 bitstring = "^3.1.7"
 psycopg2-binary = { version = "^2.8.6", optional = true }
@@ -55,10 +55,10 @@ elasticsearch = { version = "^7.11.0", optional = true }
 deepmerge = "^0.1.1"
 tinymongo = "^0.2.0"
 # TODO: Avoid specifying git repository when PR `https://github.com/alonho/pql/pull/30` is merged
-#pql = [
-#    { git = "https://github.com/comfuture/pql.git", rev = "358c42b7aa15634268c41850a01a4ff9f5c0994f", python = ">=3.7" },
-#    { version = "<=0.4.3", python = "<3.7" }
-#]
+pql = [
+    { git = "https://github.com/comfuture/pql.git", rev = "358c42b7aa15634268c41850a01a4ff9f5c0994f", python = ">=3.7" },
+    { version = "<=0.4.3", python = "<3.7" }
+]
 flatten-dict = "^0.3.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "pydtk"
-version = "0.1.0"
+version = "0.0.0"
 description = "A Python toolkit for managing, retrieving and processing data."
 license = "Apache-2.0"
 authors = [
@@ -21,6 +21,9 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Operating System :: POSIX :: Linux",
     "Topic :: Software Development :: Libraries :: Python Modules"
+]
+include = [
+    "LICENSE",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## What?
Add GitHub workflow `on_release.yaml` to publish a pre-built package on release

## Why?
To automate workflow

## Notes
- Current implementation is published as v0.0.0 to reserve name `pydtk` in PyPI
- Git dependencies must be removed from `pyproject.toml` to publish