### PR TITLE
Support for `display_name` in V4DBHandler

### DIFF
--- a/pydtk/conf/v4.yaml
+++ b/pydtk/conf/v4.yaml
@@ -53,48 +53,63 @@ db:
         - name: description
           dtype: string
           aggregation: first
+          display_name: Description
         - name: database_id
           dtype: string
           aggregation: first
+          display_name: Database ID
         - name: record_id
           dtype: string
           aggregation: first
+          display_name: Record ID
         - name: sub_record_id
           dtype: string
           aggregation: push
+          display_name: Sub Record ID
         - name: data_type
           dtype: string
           aggregation: push
+          display_name: Data type
         - name: path
           dtype: string
           aggregation: push
+          display_name: File path
         - name: start_timestamp
           dtype: float
           aggregation: min
+          display_name: Start timestamp
         - name: end_timestamp
           dtype: float
           aggregation: max
+          display_name: End timestamp
         - name: content_type
           dtype: string
           aggregation: push
+          display_name: Content type
         - name: contents
           dtype: string
           aggregation: mergeObjects
+          display_name: Contents
         - name: msg_type
           dtype: string
           aggregation: push
+          display_name: Msg type
         - name: msg_md5sum
           dtype: string
           aggregation: push
+          display_name: Msg md5sum
         - name: count
           dtype: int
           aggregation: push
+          display_name: Count
         - name: frequency
           dtype: float
           aggregation: push
+          display_name: Frequency
         - name: tags
           dtype: string[]
           aggregation: addToSet
+          display_name: Tags
       index_columns:
         - database_id
         - record_id

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -481,7 +481,8 @@ class BaseDBHandler(object):
             new_columns.append({
                 'name': name,
                 'dtype': dtype,
-                'aggregation': aggregation
+                'aggregation': aggregation,
+                'display_name': name,
             })
         columns += new_columns
         self._config['columns'] = columns
@@ -531,6 +532,23 @@ class BaseDBHandler(object):
         df = pd.concat([df, pd.DataFrame.from_records(dicts)])
         return df
 
+    def _to_display_names(self, df, inplace=False):
+        """Rename columns to display-names.
+
+        Args:
+            df (pd.DataFrame): A data-frame
+            inplace (bool): If true, df will be modified in-place.
+
+        Returns:
+            (pd.DataFrame): A data-frame with renamed columns if inplace=false, otherwise None.
+
+        """
+        column_renames = {
+            c['name']: c['display_name'] for c in self._config['columns']
+            if isinstance(c, dict) and 'name' in c.keys() and 'display_name' in c.keys()
+        }
+        return df.rename(columns=column_renames, inplace=inplace)
+
     @property
     def data(self):
         """Return data.
@@ -556,12 +574,14 @@ class BaseDBHandler(object):
     @property
     def columns(self):
         """Return columns of DF."""
-        return self.df.columns.tolist()
+        df = self._df_from_dicts(self.data)
+        return df.columns.tolist()
 
     @property
     def df(self):
         """Return df."""
         df = self._df_from_dicts(self.data)
+        df = self._to_display_names(df)
         return df
 
     @property

--- a/pydtk/db/v4/handlers/meta.py
+++ b/pydtk/db/v4/handlers/meta.py
@@ -274,7 +274,7 @@ class MetaDBHandler(_BaseDBHandler):
         )
 
     @property
-    def df(self):
+    def _df(self):
         """Return df."""
         data = []
         for idx in range(len(self)):
@@ -304,14 +304,22 @@ class MetaDBHandler(_BaseDBHandler):
         return df
 
     @property
+    def df(self):
+        """Return df with display_names."""
+        df = self._df
+        self._to_display_names(df, inplace=True)
+        return df
+
+    @property
     def content_df(self):
         """Return content_df.
 
         Columns: record_id, path, content, msg_type, tag
 
         """
-        df = self.df[['record_id', 'path', 'contents', 'msg_type', 'tags']]
+        df = self._df[['record_id', 'path', 'contents', 'msg_type', 'tags']]
         df = df.rename(columns={"contents": "content", "tags": "tag"})
+        self._to_display_names(df, inplace=True)
         return df
 
     @property
@@ -321,7 +329,7 @@ class MetaDBHandler(_BaseDBHandler):
         Columns: path, record_id, type, content_type, start_timestamp, end_timestamp
 
         """
-        df = self.df[[
+        df = self._df[[
             'path',
             'record_id',
             'data_type',
@@ -337,6 +345,7 @@ class MetaDBHandler(_BaseDBHandler):
             'start_timestamp': 'min',
             'end_timestamp': 'max',
         })
+        self._to_display_names(df, inplace=True)
         return df
 
     @property
@@ -346,13 +355,14 @@ class MetaDBHandler(_BaseDBHandler):
         Columns: 'record_id', 'duration', 'start_timestamp', 'end_timestamp', 'tags'
 
         """
-        df = self.df[['record_id', 'start_timestamp', 'end_timestamp', 'tags']]
+        df = self._df[['record_id', 'start_timestamp', 'end_timestamp', 'tags']]
         df = df.groupby(['record_id'], as_index=False).agg({
             'start_timestamp': 'min',
             'end_timestamp': 'max',
             'tags': 'sum'
         })
         df['duration'] = df.end_timestamp - df.start_timestamp
+        self._to_display_names(df, inplace=True)
         return df
 
 

--- a/test/test_db_v4.py
+++ b/test/test_db_v4.py
@@ -628,6 +628,40 @@ def test_add_columns(
     handler.save()
 
 
+@pytest.mark.parametrize(db_args, db_list)
+def test_display_name(
+    db_engine: str,
+    db_host: str,
+    db_username: Optional[str],
+    db_password: Optional[str]
+):
+    """Test for display_name in configs.
+
+    Args:
+        db_engine (str): DB engine (e.g., 'tinydb')
+        db_host (str): Host of path of DB
+        db_username (str): Username
+        db_password (str): Password
+
+    """
+    handler = V4DBHandler(
+        db_class='meta',
+        db_engine=db_engine,
+        db_host=db_host,
+        db_username=db_username,
+        db_password=db_password,
+        base_dir_path='/opt/pydtk/test',
+        orient='contents'
+    )
+    assert isinstance(handler, V4MetaDBHandler)
+
+    reserved_names = ['_id', '_uuid', '_creation_time']
+    names = [c for c in handler.columns if c not in reserved_names]
+    display_names = [c for c in handler.df.columns.tolist() if c not in reserved_names]
+    assert all([n in [c['name'] for c in handler.config['columns']] for n in names])
+    assert all([n in [c['display_name'] for c in handler.config['columns']] for n in display_names])
+
+
 if __name__ == '__main__':
     test_create_db(*default_db_parameter)
     test_load_db(*default_db_parameter)


### PR DESCRIPTION
## What?
Support for customizing names for columns to display in V4DBHandler.
This resolves #36 

## Why?
This feature is useful in case you want to rename columns to display after adding metadata.

## See also [Optional]
https://www.notion.so/humandatawarelab/V4DBHandler-179102ec58db4bf596559e5b976b467b
