### PR TITLE
Fix the bug that `generate_contents_meta` returns list but not dict

### DIFF
--- a/pydtk/models/csv.py
+++ b/pydtk/models/csv.py
@@ -67,7 +67,7 @@ class GenericCsvModel(BaseModel, ABC):
             content_key (str): Key of content
 
         Returns:
-            (list): contents metadata
+            (dict): contents metadata
 
         """
         # Load file
@@ -75,7 +75,7 @@ class GenericCsvModel(BaseModel, ABC):
         columns = data.columns.tolist()
 
         # Generate metadata
-        contents = [{content_key: {'columns': columns, 'tags': ['csv']}}]
+        contents = {content_key: {'columns': columns, 'tags': ['csv']}}
 
         return contents
 

--- a/pydtk/models/json_model.py
+++ b/pydtk/models/json_model.py
@@ -65,7 +65,7 @@ class GenericJsonModel(BaseModel, ABC):
             content_key (str): Key of content
 
         Returns:
-            (list): contents metadata
+            (dict): contents metadata
 
         """
         # Load file
@@ -78,7 +78,7 @@ class GenericJsonModel(BaseModel, ABC):
             )
 
         # Generate metadata
-        contents = [{content_key: {'keys': [data.keys()], 'tags': ['json']}}]
+        contents = {content_key: {'keys': [data.keys()], 'tags': ['json']}}
         return contents
 
     @classmethod

--- a/pydtk/models/movie.py
+++ b/pydtk/models/movie.py
@@ -136,7 +136,7 @@ class GenericMovieModel(BaseModel, ABC):
             path (str): File path
 
         Returns:
-            (list): contents metadata
+            (dict): contents metadata
 
         """
         raise NotImplementedError

--- a/pydtk/models/pointcloud/pcd.py
+++ b/pydtk/models/pointcloud/pcd.py
@@ -99,7 +99,7 @@ class PCDModel(BaseModel, ABC):
             path (str): File path
 
         Returns:
-            (list): contents metadata
+            (dict): contents metadata
 
         """
         raise NotImplementedError

--- a/pydtk/models/rosbag.py
+++ b/pydtk/models/rosbag.py
@@ -185,7 +185,7 @@ class GenericRosbagModel(BaseModel, ABC):
             content_key (str): Key of content
 
         Returns:
-            (list): contents metadata
+            (dict): contents metadata
 
         """
         # Load file

--- a/test/test_make_meta.py
+++ b/test/test_make_meta.py
@@ -31,4 +31,4 @@ def test_csv_with_contents():
 
     assert isinstance(metadata, dict)
     assert 'contents' in metadata.keys()
-    # assert isinstance(metadata['contents'], dict)   # FIXME: Remove comment-out
+    assert isinstance(metadata['contents'], dict)

--- a/test/test_make_meta.py
+++ b/test/test_make_meta.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright Toolkit Authors
+
+"""Test make-meta with pytest."""
+
+_template_with_contents = {
+    'contents': {}
+}
+
+
+def test_csv():
+    """Create metadata of a csv file."""
+    from pydtk.bin.make_meta import make_meta
+
+    path = 'test/records/annotation_model_test/annotation_test.csv'
+    metadata = make_meta(path)
+
+    assert isinstance(metadata, dict)
+    assert 'path' in metadata.keys()
+    assert metadata['path'] == path
+
+
+def test_csv_with_contents():
+    """Create metadata of a csv file."""
+    from pydtk.bin.make_meta import make_meta
+
+    path = 'test/records/annotation_model_test/annotation_test.csv'
+    metadata = make_meta(path, _template_with_contents)
+
+    assert isinstance(metadata, dict)
+    assert 'contents' in metadata.keys()
+    # assert isinstance(metadata['contents'], dict)   # FIXME: Remove comment-out


### PR DESCRIPTION
## What?
`generate_contents_meta` 関数が一部、dictではなくlist形式を返していたバグを修正

## Why?
バグ修正のため

## See also
https://github.com/dataware-tools/pydtk/issues/32#issuecomment-790514698