### PR TITLE
Support dumping metadata to stdout in meta-maker

### DIFF
--- a/pydtk/bin/make_meta.py
+++ b/pydtk/bin/make_meta.py
@@ -8,15 +8,9 @@ import os
 from collections import defaultdict
 from pydtk.io.reader import BaseFileReader
 from pydtk.models import MetaDataModel
+from pydtk.utils.utils import load_config
 
-
-common_item = {
-    "database_id": "Database ID",
-    "description": "Description",
-    "path": "File to path",
-    "type": "Type of data",
-    "contents": "Contents",
-}
+config = load_config('v4').bin.make_meta
 
 
 def make_meta_interactively(template=None):
@@ -24,11 +18,12 @@ def make_meta_interactively(template=None):
     if template is None:
         template = defaultdict(dict)
     meta = defaultdict(dict)
-    for key in common_item.keys():
+    for key in config.common_item.keys():
         if key in template.keys():
-            meta[key] = str(input(f"{common_item[key]} [{template[key]}]: ") or template[key])
+            meta[key] = \
+                str(input(f"{config.common_item[key]} [{template[key]}]: ") or template[key])
         else:
-            meta[key] = input(f"{common_item[key]}: ")
+            meta[key] = input(f"{config.common_item[key]}: ")
     return meta
 
 
@@ -79,7 +74,8 @@ def get_arguments():
     """Parse arguments."""
     parser = argparse.ArgumentParser(description="Metadata maker.")
     parser.add_argument(
-        "-it",
+        "-i",
+        "--interactive",
         action="store_true",
         help="interactive mode",
     )

--- a/pydtk/bin/make_meta.py
+++ b/pydtk/bin/make_meta.py
@@ -4,12 +4,11 @@ import argparse
 import json
 import logging
 import os
-import sys
 
 from collections import defaultdict
 from pydtk.io.reader import BaseFileReader
 from pydtk.models import MetaDataModel
-from pydtk.utils.utils import load_config
+from pydtk.utils.utils import load_config, smart_open
 
 config = load_config('v4').bin.make_meta
 
@@ -95,7 +94,7 @@ def get_arguments():
     parser.add_argument(
         "--out_dir",
         type=str,
-        default="./",
+        default=None,
         help="output directory",
     )
     return parser.parse_args()
@@ -122,9 +121,12 @@ def main():
         if args.file is None:
             raise ValueError("following arguments are required: --file")
         meta = make_meta(args.file, template)
-        meta_json = os.path.join(args.out_dir, os.path.basename(args.file) + ".json")
+        if args.out_dir is None:
+            meta_json = None
+        else:
+            meta_json = os.path.join(args.out_dir, os.path.basename(args.file) + ".json")
 
-    with open(meta_json, "wt") as f:
+    with smart_open(meta_json, "wt") as f:
         json.dump(meta, f, indent=4)
     logging.info(f"Dumped: {meta_json}")
 

--- a/pydtk/bin/make_meta.py
+++ b/pydtk/bin/make_meta.py
@@ -6,9 +6,8 @@ import logging
 import os
 
 from collections import defaultdict
-
-from pydtk.io import NoModelMatchedError
-from pydtk.models import MODELS_BY_PRIORITY
+from pydtk.io.reader import BaseFileReader
+from pydtk.models import MetaDataModel
 
 
 common_item = {
@@ -54,7 +53,8 @@ def _get_contents_info(file_path):
         (dict): contents info
 
     """
-    model = _select_model(file_path)
+    metadata = MetaDataModel(data={'path': file_path})
+    model = BaseFileReader._select_model(metadata)
     contents = model.generate_contents_meta(path=file_path)
     return contents
 
@@ -69,24 +69,10 @@ def _get_timestamps_info(file_path):
         (list): [start_timestamp, end_timestamp]
 
     """
-    model = _select_model(file_path)
+    metadata = MetaDataModel(data={'path': file_path})
+    model = BaseFileReader._select_model(metadata)
     timetamps_info = model.generate_timestamp_meta(path=file_path)
     return timetamps_info
-
-
-def _select_model(file_path):
-    """Select a proper model based on the given file-metadata.
-
-    Args:
-        file_path (str): File path
-
-    """
-    priorities = MODELS_BY_PRIORITY.keys()
-    for priority in sorted(priorities, reverse=True):
-        for model in MODELS_BY_PRIORITY[priority]:
-            if model.is_loadable(path=file_path):
-                return model
-    raise NoModelMatchedError('No suitable model found for loading data: {}'.format(file_path))
 
 
 def get_arguments():

--- a/pydtk/bin/make_meta.py
+++ b/pydtk/bin/make_meta.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import logging
 import os
+import sys
 
 from collections import defaultdict
 from pydtk.io.reader import BaseFileReader
@@ -114,7 +115,7 @@ def main():
     else:
         template = None
 
-    if args.it:
+    if args.interactive:
         meta = make_meta_interactively(template)
         meta_json = input("output json: ")
     else:

--- a/pydtk/conf/v4.yaml
+++ b/pydtk/conf/v4.yaml
@@ -1,3 +1,12 @@
+bin:
+  make_meta:
+    common_item:
+      database_id: "Database ID"
+      description: "Description"
+      path: "File to path"
+      type: "Type of data"
+      contents: "Contents"
+
 db:
   connection:
     base:

--- a/pydtk/utils/utils.py
+++ b/pydtk/utils/utils.py
@@ -256,6 +256,7 @@ def _deepmerge_append_list_unique(config, path, base, nxt):
 @contextlib.contextmanager
 def smart_open(filename: str = None, mode: str = 'r', *args, **kwargs):
     """Open files and i/o streams transparently.
+
     Reference:
     https://stackoverflow.com/questions/17602878/how-to-handle-both-with-open-and-sys-stdout-nicely
 
@@ -273,7 +274,7 @@ def smart_open(filename: str = None, mode: str = 'r', *args, **kwargs):
         else:
             stream = sys.stdout
         if 'b' in mode:
-            fh = stream.buffer  # type: IO
+            fh = stream.buffer
         else:
             fh = stream
         close = False


### PR DESCRIPTION
## What?
- meta-maker で `--out_dir` オプションを指定しないと標準出力にメタ情報を出力する仕様に変更
- `_select_model` が `pydtk.io.reader` 内の実装とダブっていたので置き換え
- `common_item` を `pydtk/conf/v4.yaml` に移動

## Why?
- dockerコンテナ経由でメタ情報を生成する際に、出力ディレクトリをマウントしたりするのが面倒なのでこういう仕様にしてみました