### PR TITLE
Remove option `-E tinydb` in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN poetry install \
   -E mysql \
   -E postgresql \
   -E pointcloud \
-  -E tinydb \
   -E mongodb \
   -E elasticsearch \
   || poetry update


### PR DESCRIPTION
## What?
Dockerfile 内での `poetry install` での `-E tinydb` オプションを削除

## Why?
`pyproject.toml` に `tinydb` のエクストラが無いから