### PR TITLE
Fix the order of processes on saving records to DB

### DIFF
--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -415,9 +415,9 @@ class BaseDBHandler(object):
 
     def save(self, **kwargs):
         """Save data to DB."""
-        self._upsert(list(self._data.values()))
         self._remove(self._uuids_to_remove)
         self._uuids_to_remove = []
+        self._upsert(list(self._data.values()))
         self._save_config_to_db()
 
     def _remove(self, uuids):


### PR DESCRIPTION
## What?
V4DBHandler の `save` 関数内での動作の順番を修正:

(修正前)
1. `upsert` で既存のデータの更新 & 新規データの登録
2.  削除リスト `_uuids_to_remove` に登録されているIDのデータを削除

(修正前)
1.  削除リスト `_uuids_to_remove` に登録されているIDのデータを削除
2. `upsert` で既存のデータの更新 & 新規データの登録

## Why?
同一IDのデータをローカル上で削除してから追加した場合、 修正前の動作だと `save` 時に消えてしまうため
