### PR TITLE
Fix dtype_string_to_dtype_object

### DIFF
--- a/pydtk/utils/utils.py
+++ b/pydtk/utils/utils.py
@@ -237,7 +237,10 @@ def listed_dict_to_dict_1d(dict_in):
 
 def dtype_string_to_dtype_object(dtype):
     """Return object corresponds to the input string."""
-    return DTYPE_MAP[dtype]
+    try:
+        return DTYPE_MAP[dtype]
+    except KeyError:
+        return object
 
 
 def _deepmerge_append_list_unique(config, path, base, nxt):


### PR DESCRIPTION
## What?
関数 `dtype_string_to_dtype_object` で `DTYPE_MAP` に登録されていないデータ型が含まれる場合に `object` を返す仕様に変更
(DataFrameへの変換用に使用)

## Why?
`DTYPE_MAP` にハードコーディングされていないデータ型が `config['columns']` に含まれていると例外で落ちてしまうのを防ぐため