### PR TITLE
Reduce default columns of V4DBHandler

### DIFF
--- a/pydtk/__init__.py
+++ b/pydtk/__init__.py
@@ -1,4 +1,4 @@
 """pydtk modules."""
 
 __version__ = "0.0.0-0"
-__commit_id__ = "a4e53a1e6a421e2972ffc4bf2d744f44b89121bf"
+__commit_id__ = "155539b525852415d54bfb087ed2d8820735b3f5"

--- a/pydtk/conf/v4.yaml
+++ b/pydtk/conf/v4.yaml
@@ -1,7 +1,7 @@
 bin:
   make_meta:
     common_item:
-      database_id: "Database ID"
+      record_id: "Record ID"
       description: "Description"
       path: "File to path"
       type: "Type of data"
@@ -63,64 +63,23 @@ db:
           dtype: string
           aggregation: first
           display_name: Description
-        - name: database_id
-          dtype: string
-          aggregation: first
-          display_name: Database ID
         - name: record_id
           dtype: string
           aggregation: first
           display_name: Record ID
-        - name: sub_record_id
-          dtype: string
-          aggregation: push
-          display_name: Sub Record ID
-        - name: data_type
-          dtype: string
-          aggregation: push
-          display_name: Data type
         - name: path
           dtype: string
           aggregation: push
           display_name: File path
-        - name: start_timestamp
-          dtype: float
-          aggregation: min
-          display_name: Start timestamp
-        - name: end_timestamp
-          dtype: float
-          aggregation: max
-          display_name: End timestamp
-        - name: content_type
-          dtype: string
-          aggregation: push
-          display_name: Content type
         - name: contents
           dtype: string
           aggregation: mergeObjects
           display_name: Contents
-        - name: msg_type
-          dtype: string
-          aggregation: push
-          display_name: Msg type
-        - name: msg_md5sum
-          dtype: string
-          aggregation: push
-          display_name: Msg md5sum
-        - name: count
-          dtype: int
-          aggregation: push
-          display_name: Count
-        - name: frequency
-          dtype: float
-          aggregation: push
-          display_name: Frequency
         - name: tags
           dtype: string[]
           aggregation: addToSet
           display_name: Tags
       index_columns:
-        - database_id
         - record_id
         - path
     time_series_df:

--- a/pydtk/db/v4/handlers/meta.py
+++ b/pydtk/db/v4/handlers/meta.py
@@ -314,10 +314,10 @@ class MetaDBHandler(_BaseDBHandler):
     def content_df(self):
         """Return content_df.
 
-        Columns: record_id, path, content, msg_type, tag
+        Columns: record_id, path, content, tag
 
         """
-        df = self._df[['record_id', 'path', 'contents', 'msg_type', 'tags']]
+        df = self._df[['record_id', 'path', 'contents', 'tags']]
         df = df.rename(columns={"contents": "content", "tags": "tag"})
         self._to_display_names(df, inplace=True)
         return df
@@ -326,24 +326,15 @@ class MetaDBHandler(_BaseDBHandler):
     def file_df(self):
         """Return file_df.
 
-        Columns: path, record_id, type, content_type, start_timestamp, end_timestamp
+        Columns: path, record_id
 
         """
         df = self._df[[
             'path',
             'record_id',
-            'data_type',
-            'content_type',
-            'start_timestamp',
-            'end_timestamp'
         ]]
-        df = df.rename(columns={"data_type": "type", "content_type": "content-type"})
         df = df.groupby(['path'], as_index=False).agg({
             'record_id': 'first',
-            'type': 'first',
-            'content-type': 'first',
-            'start_timestamp': 'min',
-            'end_timestamp': 'max',
         })
         self._to_display_names(df, inplace=True)
         return df
@@ -352,16 +343,13 @@ class MetaDBHandler(_BaseDBHandler):
     def record_id_df(self):
         """Return record_id_df.
 
-        Columns: 'record_id', 'duration', 'start_timestamp', 'end_timestamp', 'tags'
+        Columns: 'record_id', 'tags'
 
         """
-        df = self._df[['record_id', 'start_timestamp', 'end_timestamp', 'tags']]
+        df = self._df[['record_id', 'tags']]
         df = df.groupby(['record_id'], as_index=False).agg({
-            'start_timestamp': 'min',
-            'end_timestamp': 'max',
             'tags': 'sum'
         })
-        df['duration'] = df.end_timestamp - df.start_timestamp
         self._to_display_names(df, inplace=True)
         return df
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -651,7 +651,7 @@ def test_display_name(
         db_username=db_username,
         db_password=db_password,
         base_dir_path='/opt/pydtk/test',
-        orient='contents'
+        orient='path'
     )
     assert isinstance(handler, V4MetaDBHandler)
 


### PR DESCRIPTION
## What?
V4MetaDBHandler のデフォルトカラムから以下を削除
- database_id
- sub_record_id
- data_type
- start_timestamp
- end_timestamp
- content_type
- mst_type
- msg_md5
- count
- frequency

## Why?
汎用化するため