### PR TITLE
Fix the bug that CLI fails with JSON unserializable errors

### DIFF
--- a/pydtk/bin/sub_commands/db.py
+++ b/pydtk/bin/sub_commands/db.py
@@ -354,4 +354,8 @@ def _display(handler: DBHandler, columns: list = None, **kwargs):
         print(df)
 
     else:
-        print(json.dumps(handler.data, indent=4))
+        print(json.dumps(handler.data, indent=4, default=_default_json_handler))
+
+
+def _default_json_handler(o):
+    return o.__str__()

--- a/pydtk/bin/sub_commands/model.py
+++ b/pydtk/bin/sub_commands/model.py
@@ -119,4 +119,8 @@ class Model(object):
             pass
 
         # Display
-        print(json.dumps(data, indent=4))
+        print(json.dumps(data, indent=4, default=_default_json_handler))
+
+
+def _default_json_handler(o):
+    return o.__str__()


### PR DESCRIPTION
## What?
CLIが以下のようなエラーで失敗するバグを修正

```bash
TypeError: Object of type ObjectId is not JSON serializable

```

## Why?
バグ修正のため

## See also
#54 