### PR TITLE
Simplify initial columns of `MetaDBHandler`

### DIFF
--- a/pydtk/__init__.py
+++ b/pydtk/__init__.py
@@ -1,4 +1,4 @@
 """pydtk modules."""
 
 __version__ = "0.0.0-0"
-__commit_id__ = "e918d379c0281b6c475de739c348cb0698816275"
+__commit_id__ = "81db66310f90fc3d85fc23df850b43b4225ee300"

--- a/pydtk/conf/v4.yaml
+++ b/pydtk/conf/v4.yaml
@@ -2,9 +2,7 @@ bin:
   make_meta:
     common_item:
       record_id: "Record ID"
-      description: "Description"
       path: "File to path"
-      type: "Type of data"
       contents: "Contents"
 
 db:
@@ -63,10 +61,6 @@ db:
       _hash_digest_size: 4
       _df_name: 'db_{database_id}_meta'
       columns:
-        - name: description
-          dtype: string
-          aggregation: first
-          display_name: Description
         - name: record_id
           dtype: string
           aggregation: first
@@ -79,10 +73,6 @@ db:
           dtype: string
           aggregation: mergeObjects
           display_name: Contents
-        - name: tags
-          dtype: string[]
-          aggregation: addToSet
-          display_name: Tags
       index_columns:
         - record_id
         - path

--- a/pydtk/db/v4/handlers/meta.py
+++ b/pydtk/db/v4/handlers/meta.py
@@ -310,49 +310,6 @@ class MetaDBHandler(_BaseDBHandler):
         self._to_display_names(df, inplace=True)
         return df
 
-    @property
-    def content_df(self):
-        """Return content_df.
-
-        Columns: record_id, path, content, tag
-
-        """
-        df = self._df[['record_id', 'path', 'contents', 'tags']]
-        df = df.rename(columns={"contents": "content", "tags": "tag"})
-        self._to_display_names(df, inplace=True)
-        return df
-
-    @property
-    def file_df(self):
-        """Return file_df.
-
-        Columns: path, record_id
-
-        """
-        df = self._df[[
-            'path',
-            'record_id',
-        ]]
-        df = df.groupby(['path'], as_index=False).agg({
-            'record_id': 'first',
-        })
-        self._to_display_names(df, inplace=True)
-        return df
-
-    @property
-    def record_id_df(self):
-        """Return record_id_df.
-
-        Columns: 'record_id', 'tags'
-
-        """
-        df = self._df[['record_id', 'tags']]
-        df = df.groupby(['record_id'], as_index=False).agg({
-            'tags': 'sum'
-        })
-        self._to_display_names(df, inplace=True)
-        return df
-
 
 @register_handler(db_classes=['database_id'], db_engines=['tinydb', 'tinymongo', 'mongodb'])
 class DatabaseIDDBHandler(_BaseDBHandler):

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -38,13 +38,7 @@ def _add_data_to_db(handler: V4DBHandler):
 
     # Get DF
     df = handler.df
-    content_df = handler.content_df
-    file_df = handler.file_df
-    record_id_df = handler.record_id_df
     assert len(df) == len(handler) and len(df) > 0
-    assert len(content_df) == len(handler) and len(content_df) > 0
-    assert len(file_df) == len(paths)
-    assert len(record_id_df) == len(record_ids)
 
     # Save
     handler.save()


### PR DESCRIPTION
## What?
Remove `description` and `tags` from the initial columns of `MetaDBHandler`

## Why?
To simplify `MetaDBHandler`
