### PR TITLE
Default to `allowDiskUse=True` in MongoDB

### DIFF
--- a/pydtk/db/v4/engines/mongodb.py
+++ b/pydtk/db/v4/engines/mongodb.py
@@ -151,7 +151,7 @@ def read(db,
         if limit > 0:
             aggregate.append({'$limit': limit})
 
-        data = db.aggregate(aggregate)
+        data = db.aggregate(aggregate, allowDiskUse=True)
         try:
             count_total = list(db.aggregate(aggregate_count))[0]['count'] \
                 if not disable_count_total else None


### PR DESCRIPTION
## What?
Resolve https://github.com/dataware-tools/dataware-tools/issues/34
Fix the bug that listing large number of records fails with the following error.
```
pymongo.errors.OperationFailure: Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in., full error: {'ok': 0.0, 'errmsg': "Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in.", 'code': 292, 'codeName': 'QueryExceededMemoryLimitNoDiskUseAllowed'}
```

## Why?
Bug fix