### PR TITLE
Fix the bug that option `--content` had no effect in CLI

### DIFF
--- a/pydtk/bin/sub_commands/model.py
+++ b/pydtk/bin/sub_commands/model.py
@@ -117,7 +117,7 @@ class Model(object):
 
             # Get contents and timestamps
             try:
-                data["contents"] = model.generate_contents_meta(path=from_file)
+                data["contents"] = model.generate_contents_meta(path=from_file, content_key=content)
             except NotImplementedError:
                 pass
             try:
@@ -129,9 +129,6 @@ class Model(object):
         # Post process
         if record_id is not None:
             data['record_id'] = record_id
-        if content is not None:
-            # TODO: Specify content prefix
-            pass
 
         # Display
         print(json.dumps(data, indent=4, default=_default_json_handler))

--- a/pydtk/models/__init__.py
+++ b/pydtk/models/__init__.py
@@ -437,11 +437,12 @@ class BaseModel(metaclass=ABCMeta):
 
     @classmethod
     @abstractmethod
-    def generate_contents_meta(cls, path):
+    def generate_contents_meta(cls, path, content_key='content'):
         """Generate contents metadata.
 
         Args:
             path (str): File path
+            content_key (str): Key of content
 
         Returns:
             (list): contents metadata

--- a/pydtk/models/movie.py
+++ b/pydtk/models/movie.py
@@ -163,11 +163,12 @@ class GenericMovieModel(BaseModel, ABC):
         return downsampled_timestamps
 
     @classmethod
-    def generate_contents_meta(cls, path):
+    def generate_contents_meta(cls, path, content_key='content'):
         """Generate contents metadata.
 
         Args:
             path (str): File path
+            content_key (str): Key of content
 
         Returns:
             (dict): contents metadata

--- a/pydtk/models/pointcloud/pcd.py
+++ b/pydtk/models/pointcloud/pcd.py
@@ -92,11 +92,12 @@ class PCDModel(BaseModel, ABC):
         self._columns = columns
 
     @classmethod
-    def generate_contents_meta(cls, path):
+    def generate_contents_meta(cls, path, content_key='content'):
         """Generate contents metadata.
 
         Args:
             path (str): File path
+            content_key (str): Key of content
 
         Returns:
             (dict): contents metadata

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -3,6 +3,10 @@
 
 # Copyright Toolkit Authors
 
+from contextlib import redirect_stdout
+import io
+import json
+
 import pytest
 
 model_file_args = 'file_path,model'
@@ -13,6 +17,11 @@ model_file_list = [
 ]
 
 
+def _assert_content(metadata, content_key):
+    if 'contents' in metadata.keys() and isinstance(metadata['contents'], dict):
+        assert content_key in metadata['contents'].keys()
+
+
 @pytest.mark.parametrize(model_file_args, model_file_list)
 def test_model_generate_metadata(file_path, model):
     """Test `pydtk model generate metadata`."""
@@ -21,14 +30,24 @@ def test_model_generate_metadata(file_path, model):
     cli = Model()
 
     # Generate metadata without specifying a model
-    cli.generate(
-        target='metadata',
-        from_file=file_path
-    )
+    f = io.StringIO()
+    with redirect_stdout(f):
+        cli.generate(
+            target='metadata',
+            from_file=file_path,
+            content='abc'
+        )
+    metadata = json.loads(f.getvalue())
+    _assert_content(metadata, 'abc')
 
     # Generate metadata by specifying a model
-    cli.generate(
-        target='metadata',
-        model=model,
-        from_file=file_path
-    )
+    f = io.StringIO()
+    with redirect_stdout(f):
+        cli.generate(
+            target='metadata',
+            model=model,
+            from_file=file_path,
+            content='abc'
+        )
+    metadata = json.loads(f.getvalue())
+    _assert_content(metadata, 'abc')


### PR DESCRIPTION
## What?
Fix the bug that option `--content` in command `pydtk model generate metadata` had no effect

## Why?
Bug fix