### PR TITLE
Fix the bug that dtype of the input data was not fixed

### DIFF
--- a/pydtk/conf/v4.yaml
+++ b/pydtk/conf/v4.yaml
@@ -70,7 +70,7 @@ db:
           aggregation: push
           display_name: File path
         - name: contents
-          dtype: string
+          dtype: dict
           aggregation: mergeObjects
           display_name: Contents
       index_columns:

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -66,6 +66,45 @@ def register_handler(db_classes, db_engines):
     return decorator
 
 
+def _fix_data_dtype(data_in, columns, inplace=False):
+    """Fix dtype of the input data.
+
+    Args:
+        data_in (dict): input-data
+        columns (list): column configurations
+        inplace (bool): if True, this function modifies the input argument `data_in`
+
+    Returns:
+        (dict): data with corrected dtypes
+
+    """
+    data = data_in if inplace else deepcopy(data_in)
+
+    for key in data.keys():
+        if key.startswith('_'):
+            continue
+        try:
+            column_conf = next(filter(lambda c: c['name'] == key, columns))
+        except StopIteration:
+            continue
+        if 'dtype' not in column_conf.keys():
+            continue
+        if column_conf['dtype'].lower() in ['string', 'str']:
+            data[key] = str(data[key])
+        elif column_conf['dtype'].lower() in ['integer', 'int']:
+            data[key] = int(data[key])
+        elif column_conf['dtype'].lower() in ['float', 'double', 'number']:
+            data[key] = float(data[key])
+        elif column_conf['dtype'].lower() in ['list'] or column_conf['dtype'].endswith('[]'):
+            data[key] = list(data[key])
+        elif column_conf['dtype'].lower() in ['dict']:
+            data[key] = dict(data[key])
+        else:
+            pass
+
+    return data
+
+
 class BaseDBHandler(object):
     """Base handler for db."""
 
@@ -462,7 +501,7 @@ class BaseDBHandler(object):
             raise ValueError('Unsupported DB engine: {}'.format(self._db_engine))
 
     def add_data(self, data_in, strategy='overwrite', **kwargs):
-        """Add data to db.
+        """Add data to DB-handler.
 
         Args:
             data_in (dict): a dict containing data
@@ -498,12 +537,16 @@ class BaseDBHandler(object):
                 'display_name': name,
             })
         columns += new_columns
-        self._config['columns'] = columns
 
+        # Fix dtype of the input data
+        _fix_data_dtype(data, columns, inplace=True)
+
+        # Update self
+        self._config['columns'] = columns
         self._data.update({data['_uuid']: data})
 
     def remove_data(self, data):
-        """Remove data-record from DB.
+        """Remove data-record from DB-handler.
 
         Args:
             data (dict): a dict containing the target data or '_uuid' in keys.

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -66,7 +66,7 @@ def register_handler(db_classes, db_engines):
     return decorator
 
 
-def _fix_data_dtype(data_in, columns, inplace=False):
+def _fix_data_type(data_in, columns, inplace=False):
     """Fix dtype of the input data.
 
     Args:
@@ -542,7 +542,7 @@ class BaseDBHandler(object):
 
         # Fix dtype of the input data
         if not ignore_dtype_mismatch:
-            _fix_data_dtype(data, columns, inplace=True)
+            _fix_data_type(data, columns, inplace=True)
 
         # Update self
         self._config['columns'] = columns

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -500,12 +500,14 @@ class BaseDBHandler(object):
         else:
             raise ValueError('Unsupported DB engine: {}'.format(self._db_engine))
 
-    def add_data(self, data_in, strategy='overwrite', **kwargs):
+    def add_data(self, data_in, strategy='overwrite', ignore_dtype_mismatch=False, **kwargs):
         """Add data to DB-handler.
 
         Args:
             data_in (dict): a dict containing data
             strategy (str): 'merge' or 'overwrite'
+            ignore_dtype_mismatch (bool): if True, data type will not be modified
+                                          regardless of column specifications
 
         """
         assert strategy in ['merge', 'overwrite'], 'Unknown strategy.'
@@ -539,7 +541,8 @@ class BaseDBHandler(object):
         columns += new_columns
 
         # Fix dtype of the input data
-        _fix_data_dtype(data, columns, inplace=True)
+        if not ignore_dtype_mismatch:
+            _fix_data_dtype(data, columns, inplace=True)
 
         # Update self
         self._config['columns'] = columns

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -690,6 +690,49 @@ def test_read_with_offset(
     assert handler.df.index[0] == 1
 
 
+@pytest.mark.parametrize(db_args, db_list)
+def test_db_handler_dtype(
+    db_engine: str,
+    db_host: str,
+    db_username: Optional[str],
+    db_password: Optional[str]
+):
+    """Test for checking data-types handled by DBHandler.
+
+    Args:
+        db_engine (str): DB engine (e.g., 'tinydb')
+        db_host (str): Host of path of DB
+        db_username (str): Username
+        db_password (str): Password
+
+    """
+    from pydtk.db import DBHandler
+    handler = DBHandler(db_class='meta')
+    handler.add_data({
+        'record_id': 1,
+        'path': 'abc',
+        'contents': {},
+        'new_column_str': '',
+        'new_column_int': 1,
+        'new_column_float': 1.234,
+        'new_column_list': [],
+        'new_column_dict': {}
+    })
+    assert isinstance(handler.data[0]['record_id'], str)
+    assert isinstance(handler.data[0]['path'], str)
+    assert isinstance(handler.data[0]['contents'], dict)
+    assert isinstance(handler.data[0]['new_column_str'], str)
+    assert isinstance(handler.data[0]['new_column_int'], int)
+    assert isinstance(handler.data[0]['new_column_float'], float)
+    assert isinstance(handler.data[0]['new_column_list'], list)
+    assert isinstance(handler.data[0]['new_column_dict'], dict)
+    handler.save()
+
+    handler = DBHandler(db_class='meta')
+    handler.read(pql='"record_id" == regex(".*")')
+    assert len(handler) > 0
+
+
 if __name__ == '__main__':
     test_create_db(*default_db_parameter)
     test_load_db(*default_db_parameter)


### PR DESCRIPTION
## What?
Add a function to fix data-type of the input data and call it on `add_data` in DBHandler
Fix #73 and dataware-tools/dataware-tools#50

## Why?
Bug fix
