### PR TITLE
overwrite option (command: db add)

### DIFF
--- a/pydtk/bin/sub_commands/db.py
+++ b/pydtk/bin/sub_commands/db.py
@@ -364,7 +364,6 @@ def _display(handler: DBHandler, columns: list = None, **kwargs):
     if 'parsable' in kwargs and kwargs['parsable']:
         parsable = True
 
-
     if not parsable:
         available_columns = [column for column in handler.df.columns if not column.startswith('_')]
         if columns is not None:

--- a/pydtk/bin/sub_commands/db.py
+++ b/pydtk/bin/sub_commands/db.py
@@ -14,6 +14,8 @@ pandas.set_option('display.width', None)
 
 
 class EmptySTDINError(Exception):
+    """Exception for the case that STDIN is empty."""
+
     pass
 
 

--- a/pydtk/bin/sub_commands/db.py
+++ b/pydtk/bin/sub_commands/db.py
@@ -158,6 +158,7 @@ class DB(object):
         path: str = None,
         content: str = None,
         base_dir: str = '/',
+        display: bool = True,
         **kwargs
     ):
         """Get resources.
@@ -197,7 +198,8 @@ class DB(object):
         handler.read(pql=pql, group_by=group_by)
 
         # Display
-        _display(handler, **kwargs)
+        if display:
+            _display(handler, **kwargs)
 
         self._handler = handler
 
@@ -208,6 +210,7 @@ class DB(object):
         database_id: str = 'default',
         base_dir: str = '/',
         overwrite: bool = False,
+        display: bool = False,
         **kwargs
     ):
         """Add resources.
@@ -242,7 +245,8 @@ class DB(object):
             self.get(
                 target=target,
                 database_id=database_id,
-                base_dir_path=base_dir
+                base_dir_path=base_dir,
+                display=display,
             )
             handler = self._handler
 

--- a/pydtk/bin/sub_commands/db.py
+++ b/pydtk/bin/sub_commands/db.py
@@ -158,8 +158,7 @@ class DB(object):
         path: str = None,
         content: str = None,
         base_dir: str = '/',
-        display: bool = True,
-        **kwargs
+        **kwargs,
     ):
         """Get resources.
 
@@ -198,8 +197,7 @@ class DB(object):
         handler.read(pql=pql, group_by=group_by)
 
         # Display
-        if display:
-            _display(handler, **kwargs)
+        _display(handler, **kwargs)
 
         self._handler = handler
 
@@ -210,8 +208,7 @@ class DB(object):
         database_id: str = 'default',
         base_dir: str = '/',
         overwrite: bool = False,
-        display: bool = False,
-        **kwargs
+        **kwargs,
     ):
         """Add resources.
 
@@ -246,7 +243,7 @@ class DB(object):
                 target=target,
                 database_id=database_id,
                 base_dir_path=base_dir,
-                display=display,
+                **kwargs,
             )
             handler = self._handler
 
@@ -360,10 +357,13 @@ def _display(handler: DBHandler, columns: list = None, **kwargs):
 
     """
     parsable = False
+    if 'quiet' in kwargs and kwargs['quiet']:
+        return
     if 'p' in kwargs and kwargs['p']:
         parsable = True
     if 'parsable' in kwargs and kwargs['parsable']:
         parsable = True
+
 
     if not parsable:
         available_columns = [column for column in handler.df.columns if not column.startswith('_')]

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -451,6 +451,7 @@ class BaseDBHandler(object):
         }
 
         self._data = {record['_uuid']: record for record in data}
+        self._uuids_duplicated = []
 
     def _upsert(self, data):
         """Upsert data to DB.
@@ -470,6 +471,7 @@ class BaseDBHandler(object):
         """Save data to DB."""
         self._remove(self._uuids_to_remove)
         self._uuids_to_remove = []
+        self._uuids_duplicated = []
         self._upsert(list(self._data.values()))
         self._save_config_to_db()
 

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -197,6 +197,7 @@ class BaseDBHandler(object):
         self.logger = logging.getLogger(__name__)
         self._cursor = 0
         self._data = {}
+        self._uuids_duplicated = []
         self._uuids_to_remove = []
         self._count_total = 0
         if df_name is not None:
@@ -522,6 +523,7 @@ class BaseDBHandler(object):
             if strategy == 'merge':
                 base_data = self._data[data['_uuid']]
                 data = self._merger.merge(base_data, data)
+            self._uuids_duplicated += [data['_uuid']]
 
         # Add new columns (keys) to config
         columns = self._config['columns'] if 'columns' in self._config.keys() else []

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -162,3 +162,94 @@ def test_db_add_and_delete_file():
         handler, _ = _get_db_handler(target='file', database_id='pytest')
         handler.read()
         assert len(handler) == 0
+
+
+def test_db_add_database():
+    """Test `pydtk db add file` and `pydtk db delete database."""
+    from pydtk.bin.sub_commands.db import DB, _get_db_handler
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        os.environ['PYDTK_META_DB_ENGINE'] = 'tinymongo'
+        os.environ['PYDTK_META_DB_HOST'] = tmp_dir
+
+        cli = DB()
+        database_id = 'abc'
+
+        # Add 1 database
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.add(
+                target='database',
+                content=database_id,
+                overwrite=True,
+                skip_checking_existence=True,
+            )
+        metadata = f.getvalue()
+        assert 'Added: 1 items.' in metadata
+
+        # Make sure that the data was deleted
+        handler, _ = _get_db_handler(target='database')
+        handler.read()
+        assert next(handler)['database_id'] == database_id
+
+
+def test_db_add_database_from_stdin():
+    """Test `pydtk db add file` and `pydtk db delete database."""
+    from pydtk.bin.sub_commands.db import DB, _get_db_handler
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        os.environ['PYDTK_META_DB_ENGINE'] = 'tinymongo'
+        os.environ['PYDTK_META_DB_HOST'] = tmp_dir
+
+        cli = DB()
+        database_id = 'abc'
+
+        # Add 1 database
+        sys.stdin = io.StringIO(json.dumps({
+            'database_id': database_id,
+            'name': database_id,
+            'description': 'description'
+        }))
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.add(
+                target='database',
+                overwrite=True,
+                skip_checking_existence=True,
+            )
+        metadata = f.getvalue()
+        assert 'Added: 1 items.' in metadata
+
+        # Make sure that the data was deleted
+        handler, _ = _get_db_handler(target='database')
+        handler.read()
+        assert next(handler)['database_id'] == database_id
+
+
+def test_db_add_database_2():
+    """Test `pydtk db add file` and `pydtk db delete database."""
+    from pydtk.bin.sub_commands.db import DB, _get_db_handler
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        os.environ['PYDTK_META_DB_ENGINE'] = 'tinymongo'
+        os.environ['PYDTK_META_DB_HOST'] = tmp_dir
+
+        cli = DB()
+        database_id = 'abc'
+
+        # Add 1 database
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.add(
+                target='database',
+                database_id=database_id,
+                overwrite=True,
+                skip_checking_existence=True,
+            )
+        metadata = f.getvalue()
+        assert 'Added: 1 items.' in metadata
+
+        # Make sure that the data was deleted
+        handler, _ = _get_db_handler(target='database')
+        handler.read()
+        assert next(handler)['database_id'] == database_id

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,6 +6,9 @@
 from contextlib import redirect_stdout
 import io
 import json
+import os
+import sys
+import tempfile
 
 import pytest
 
@@ -51,3 +54,111 @@ def test_model_generate_metadata(file_path, model):
         )
     metadata = json.loads(f.getvalue())
     _assert_content(metadata, 'abc')
+
+
+def test_db_add_and_delete_file():
+    """Test `pydtk db add file` and `pydtk db delete file."""
+    from pydtk.bin.sub_commands.db import DB, _get_db_handler
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        os.environ['PYDTK_META_DB_ENGINE'] = 'tinymongo'
+        os.environ['PYDTK_META_DB_HOST'] = tmp_dir
+
+        cli = DB()
+        record_id = 'abc'
+        path = '/abc'
+
+        # Add 1 file
+        sys.stdin = io.StringIO(json.dumps({
+            'record_id': record_id,
+            'path': path
+        }))
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.add(
+                target='file',
+                database_id='pytest'
+            )
+        metadata = f.getvalue()
+        assert 'Added: 1 items.' in metadata
+
+        # Check the file
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.get(
+                target='file',
+                database_id='pytest',
+                record_id=record_id,
+                path=path,
+            )
+        metadata = f.getvalue()
+        assert 'Found: 1 items.' in metadata
+
+        # Overwrite the file
+        sys.stdin = io.StringIO(json.dumps({
+            'record_id': record_id,
+            'path': path
+        }))
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.add(
+                target='file',
+                database_id='pytest',
+                overwrite=True,
+            )
+        metadata = f.getvalue()
+        assert 'Updated: 1 items.' in metadata
+
+        # Overwrite the file without checking existence
+        sys.stdin = io.StringIO(json.dumps({
+            'record_id': record_id,
+            'path': path
+        }))
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.add(
+                target='file',
+                database_id='pytest',
+                overwrite=True,
+                skip_checking_existence=True,
+            )
+        metadata = f.getvalue()
+        assert 'Added: 1 items.' in metadata
+
+        # Add another file
+        sys.stdin = io.StringIO(json.dumps({
+            'record_id': record_id,
+        }))
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.add(
+                target='file',
+                database_id='pytest'
+            )
+        metadata = f.getvalue()
+        assert 'Added: 1 items.' in metadata
+
+        # Delete the file
+        sys.stdin = io.StringIO(json.dumps([
+            {
+                'record_id': record_id,
+                'path': path
+            },
+            {
+                'record_id': record_id,
+            },
+        ]))
+        f = io.StringIO()
+        with redirect_stdout(f):
+            cli.delete(
+                target='file',
+                database_id='pytest',
+                yes=True,
+            )
+        metadata = f.getvalue()
+        assert 'Deleted: 2 items.' in metadata
+
+        # Make sure that the data was deleted
+        handler, _ = _get_db_handler(target='file', database_id='pytest')
+        handler.read()
+        assert len(handler) == 0


### PR DESCRIPTION
## What?
- cli db add コマンドの上書きオプション`--overwrite`を追加

## Why?
- `record_id`および`path`が同一の場合、ユーザに通知せずにDBを上書きしてしまうため、上書きしてしまう際は警告を通知するようにした。

## See also [Optional]
- https://github.com/dataware-tools/dataware-tools/issues/25

## Screenshot or video [Optional]
