### PR TITLE
Hide tracebacks in CLI unless `--verbose` option is set

### DIFF
--- a/pydtk/bin/cli.py
+++ b/pydtk/bin/cli.py
@@ -74,6 +74,7 @@ def script():
         logging.basicConfig(level=logging.DEBUG)
     else:
         logging.basicConfig(level=logging.ERROR)
+        sys.tracebacklimit = 0
 
     # Check args
     _check_pep515(sys.argv)


### PR DESCRIPTION
## What?
Set default to hide tracebacks in CLI and only show them when `--verbose` option is used.

## Why?
To improve user experiences

