### PR TITLE
Fix the bug that cascaded tables were dropped before `save()` is called

### DIFF
--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -507,7 +507,7 @@ class BaseDBHandler(object):
             raise ValueError('Unsupported DB engine: {}'.format(self._db_engine))
 
     def drop_table(self, name):
-        """Drop table from DB (This will no be applied without `save()` is called).
+        """Drop table from DB (This will no be applied unless `save()` is called).
 
         Args:
             name (str): Name of table (collection)

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -199,6 +199,7 @@ class BaseDBHandler(object):
         self._data = {}
         self._uuids_duplicated = []
         self._uuids_to_remove = []
+        self._tables_to_drop = []
         self._count_total = 0
         if df_name is not None:
             self.df_name = df_name
@@ -470,6 +471,8 @@ class BaseDBHandler(object):
     def save(self, **kwargs):
         """Save data to DB."""
         self._remove(self._uuids_to_remove)
+        for table_name in self._tables_to_drop:
+            self._drop_table(table_name)
         self._uuids_to_remove = []
         self._uuids_duplicated = []
         self._upsert(list(self._data.values()))
@@ -502,6 +505,16 @@ class BaseDBHandler(object):
             DB_ENGINES[self._db_engine].drop_table(self._db, name)
         else:
             raise ValueError('Unsupported DB engine: {}'.format(self._db_engine))
+
+    def drop_table(self, name):
+        """Drop table from DB (This will no be applied without `save()` is called).
+
+        Args:
+            name (str): Name of table (collection)
+
+        """
+        # Remove from DB on saving
+        self._tables_to_drop.append(name)
 
     def add_data(self, data_in, strategy='overwrite', ignore_dtype_mismatch=False, **kwargs):
         """Add data to DB-handler.

--- a/pydtk/db/v4/handlers/meta.py
+++ b/pydtk/db/v4/handlers/meta.py
@@ -351,7 +351,7 @@ class DatabaseIDDBHandler(_BaseDBHandler):
         if cascade:
             if 'df_name' in data.keys():
                 target_collection = data['df_name']
-                super()._drop_table(target_collection)
+                super().drop_table(target_collection)
             else:
                 logging.warning(
                     'Skipped dropping the corresponding table '


### PR DESCRIPTION
## What?
Fix the bug that `DatabaseIDDBHandler.remove_data` drops the table which stores the metadata of the corresponding database-id before executing `save()`.

## Why?
Bug fix

## Related issues
#81 

## Note
Test case `_test_remove_database_id` is added for this fix, but disabled as PyDTK does not support dropping tables with TinyDB < 4.  
This should be enabled when #83 is resolved.