### PR TITLE
Fix `generate_contents_meta` of GenericJsonModel

### DIFF
--- a/pydtk/models/json_model.py
+++ b/pydtk/models/json_model.py
@@ -78,7 +78,7 @@ class GenericJsonModel(BaseModel, ABC):
             )
 
         # Generate metadata
-        contents = {content_key: {'keys': [data.keys()], 'tags': ['json']}}
+        contents = {content_key: {'keys': list(data.keys()), 'tags': ['json']}}
         return contents
 
     @classmethod


### PR DESCRIPTION
## What?
Fix the issue that metadata of json files was not generated properly.

## Why?
Bug fix

Before:
```json
{
    "content": {
        "keys": [
            dict_keys(["key1", "key2", ...])
        ],
        "tags": [
            "json"
        ]
    }
}
```

After:
```json
{
    "content": {
        "keys": [
            "key1", 
            "key2", 
             ...
        ],
        "tags": [
            "json"
        ]
    }
}
```