### PR TITLE
Pre-install ROS-related dependencies in docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,9 @@ cmake-build-debug
 # tox
 .tox
 
+# Pytest
+.pytest_cache/
+
 # VSCode
 .devcontainer
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Please refer the following table and install them manually with command `pip ins
 
 | PyDTK model | Required packages |
 | --- | --- |
+| rosbag.* | ros_numpy (https://github.com/eric-wieser/ros_numpy.git) |
 | pointcloud.PCDModel | pypcd (https://github.com/klintan/pypcd.git) |
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,5 +6,6 @@
 #
 
 source /opt/pydtk/.venv/bin/activate
+[[ -f /ros_entrypoint.sh ]] && source /ros_entrypoint.sh
 
 exec "$@"

--- a/docker/dev/ubuntu-ros.Dockerfile
+++ b/docker/dev/ubuntu-ros.Dockerfile
@@ -25,6 +25,9 @@ RUN poetry install \
     -E pointcloud \
   )
 
+# Install ROS-related dependencies
+RUN poetry run pip install -q --no-cache-dir git+https://github.com/eric-wieser/ros_numpy.git pypcd
+
 # Copy remaining files
 COPY . /opt/pydtk
 

--- a/docker/runtime/ubuntu-ros.Dockerfile
+++ b/docker/runtime/ubuntu-ros.Dockerfile
@@ -19,6 +19,9 @@ RUN poetry install --no-dev --no-root \
     -E pointcloud \
   )
 
+# Install ROS-related dependencies
+RUN poetry run pip install -q --no-cache-dir git+https://github.com/eric-wieser/ros_numpy.git pypcd
+
 # Copy remaining files
 COPY ./README.md /opt/pydtk/README.md
 COPY ./LICENSE /opt/pydtk/LICENSE


### PR DESCRIPTION
## What?
Pre-install the following packages in docker images tagged `ubuntu-*-ros-*`.
- ros_numpy
- pypcd

## Why?
To enable ROS-related models out-of-box in containers