### PR TITLE
Fix the bug that `_load_as_generator` in `GenericZstdRosbagModel` does not work

### DIFF
--- a/pydtk/models/zstd/rosbag.py
+++ b/pydtk/models/zstd/rosbag.py
@@ -41,7 +41,9 @@ class GenericZstdRosbagModel(_GenericRosbagModel, ABC):
         """
         with pyzstd.open(path, 'rb') as f:
             f.mode = 'rb'
-            yield super()._load_as_generator(path=f, **kwargs)
+            generator = super()._load_as_generator(path=f, **kwargs)
+            for sample in generator:
+                yield sample
 
     def _save(self, path, contents=None, **kwargs):
         """Save ndarray data to a zstandard rosbag file.


### PR DESCRIPTION
## What?
Fix the bug that `_load_as_generator` in `GenericZstdRosbagModel` cannot generate samples

## Why?
Bug fix
