### PR TITLE
Fix the bug that function `register_handler` was not working properly

### DIFF
--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -40,8 +40,8 @@ def register_handlers():
 
         try:
             importlib.import_module(
-                '.'.join(['pydtk.db.v4.handlers',
-                          str(os.path.splitext(filename)[0])])
+                os.path.join('pydtk.db.v4.handlers',
+                             str(os.path.splitext(filename)[0])).replace(os.sep, '.')
             )
         except ModuleNotFoundError:
             logger.warning('Failed to load handlers in {}'.format(filename))

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -40,8 +40,9 @@ def register_handlers():
 
         try:
             importlib.import_module(
-                os.path.join('pydtk.db.v4.handlers',
-                             str(os.path.splitext(filename)[0])).replace(os.sep, '.')
+                os.path.join(
+                    "pydtk.db.v4.handlers", str(os.path.splitext(filename)[0])
+                ).replace(os.sep, ".")
             )
         except ModuleNotFoundError:
             logger.warning('Failed to load handlers in {}'.format(filename))

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -40,8 +40,8 @@ def register_handlers():
 
         try:
             importlib.import_module(
-                os.path.join('pydtk.db.v4.handlers',
-                             str(os.path.splitext(filename)[0]).replace(os.sep, '.'))
+                '.'.join(['pydtk.db.v4.handlers',
+                          str(os.path.splitext(filename)[0])])
             )
         except ModuleNotFoundError:
             logger.warning('Failed to load handlers in {}'.format(filename))


### PR DESCRIPTION
## What?
Fix function `register_handler` in `pydtk.db.v4.handlers`

## Why?
Bug fix

## Screenshot or video [Optional]
before:
```python
>>> from pydtk.db import DBHandler
Failed to load handlers in meta.py
>>> 

```

after:
```python
>>> from pydtk.db import DBHandler
>>> 

```
