### PR TITLE
Enable to specify the same start and end timestamp

### DIFF
--- a/pydtk/models/movie.py
+++ b/pydtk/models/movie.py
@@ -62,7 +62,7 @@ class GenericMovieModel(BaseModel, ABC):
         else:
             end_frame_idx = n_frames - 1
         frame_size = end_frame_idx - start_frame_idx + 1
-        assert 0 <= start_frame_idx < end_frame_idx < n_frames, "Timestamp out of range!"
+        assert 0 <= start_frame_idx <= end_frame_idx < n_frames, "Timestamp out of range!"
 
         # Read video
         cap.set(cv2.CAP_PROP_POS_FRAMES, start_frame_idx)


### PR DESCRIPTION
## What?
- Fix checking `start_frame_idx` and `end_frame_idx`

## Why?
- Although the process can read 1 frame if the same frame is specified for `start_frame_idx` and `end_frame_idx`, an error occurs when checking with assert.
When the same value is specified for `start_timestamp` and `end_timestamp`, and `floor` and `ceil` have the same value., the error will occur.

## See also [Optional]
- #110 