### PR TITLE
fix: fix property starting with underscore

### DIFF
--- a/openapi/dataware-tools.com/v1alpha1/annotation.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation.json
@@ -3,6 +3,24 @@
   "description": "Schema for annotation.",
   "type": "object",
   "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_uuid": {
+      "title": " Uuid",
+      "description": "Universally unique ID",
+      "minLength": 1,
+      "type": "string"
+    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -27,6 +45,9 @@
     }
   },
   "required": [
+    "_api_version",
+    "_kind",
+    "_uuid",
     "annotation_id",
     "generation",
     "record_id",
@@ -39,6 +60,24 @@
   "description": "Schema for annotation.",
   "type": "object",
   "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_uuid": {
+      "title": " Uuid",
+      "description": "Universally unique ID",
+      "minLength": 1,
+      "type": "string"
+    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -63,6 +102,9 @@
     }
   },
   "required": [
+    "_api_version",
+    "_kind",
+    "_uuid",
     "annotation_id",
     "generation",
     "record_id",

--- a/openapi/dataware-tools.com/v1alpha1/annotation.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation.json
@@ -15,12 +15,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "_uuid": {
-      "title": " Uuid",
-      "description": "Universally unique ID",
-      "minLength": 1,
-      "type": "string"
-    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -42,17 +36,21 @@
     "timestamp_to": {
       "title": "Timestamp To",
       "type": "number"
+    },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
     }
   },
   "required": [
     "_api_version",
     "_kind",
-    "_uuid",
     "annotation_id",
     "generation",
     "record_id",
     "timestamp_from",
-    "timestamp_to"
+    "timestamp_to",
+    "created_at"
   ]
 }
 {
@@ -72,12 +70,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "_uuid": {
-      "title": " Uuid",
-      "description": "Universally unique ID",
-      "minLength": 1,
-      "type": "string"
-    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -99,16 +91,20 @@
     "timestamp_to": {
       "title": "Timestamp To",
       "type": "number"
+    },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
     }
   },
   "required": [
     "_api_version",
     "_kind",
-    "_uuid",
     "annotation_id",
     "generation",
     "record_id",
     "timestamp_from",
-    "timestamp_to"
+    "timestamp_to",
+    "created_at"
   ]
 }

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_pixel.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_pixel.json
@@ -15,12 +15,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "_uuid": {
-      "title": " Uuid",
-      "description": "Universally unique ID",
-      "minLength": 1,
-      "type": "string"
-    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -43,6 +37,10 @@
       "title": "Timestamp To",
       "type": "number"
     },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
+    },
     "commented_image_pixel": {
       "$ref": "#/definitions/CommentedImagePixel"
     }
@@ -50,12 +48,12 @@
   "required": [
     "_api_version",
     "_kind",
-    "_uuid",
     "annotation_id",
     "generation",
     "record_id",
     "timestamp_from",
     "timestamp_to",
+    "created_at",
     "commented_image_pixel"
   ],
   "definitions": {

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_pixel.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_pixel.json
@@ -3,6 +3,24 @@
   "description": "Schema for commented image pixel annotation.",
   "type": "object",
   "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_uuid": {
+      "title": " Uuid",
+      "description": "Universally unique ID",
+      "minLength": 1,
+      "type": "string"
+    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -30,6 +48,9 @@
     }
   },
   "required": [
+    "_api_version",
+    "_kind",
+    "_uuid",
     "annotation_id",
     "generation",
     "record_id",

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_rectangular_area.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_rectangular_area.json
@@ -3,6 +3,24 @@
   "description": "Schema for commented image rectangular area annotation.",
   "type": "object",
   "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_uuid": {
+      "title": " Uuid",
+      "description": "Universally unique ID",
+      "minLength": 1,
+      "type": "string"
+    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -30,6 +48,9 @@
     }
   },
   "required": [
+    "_api_version",
+    "_kind",
+    "_uuid",
     "annotation_id",
     "generation",
     "record_id",

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_rectangular_area.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_rectangular_area.json
@@ -15,12 +15,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "_uuid": {
-      "title": " Uuid",
-      "description": "Universally unique ID",
-      "minLength": 1,
-      "type": "string"
-    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -43,6 +37,10 @@
       "title": "Timestamp To",
       "type": "number"
     },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
+    },
     "commented_image_rectangular_area": {
       "$ref": "#/definitions/CommentedImageRectangularArea"
     }
@@ -50,12 +48,12 @@
   "required": [
     "_api_version",
     "_kind",
-    "_uuid",
     "annotation_id",
     "generation",
     "record_id",
     "timestamp_from",
     "timestamp_to",
+    "created_at",
     "commented_image_rectangular_area"
   ],
   "definitions": {

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_point.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_point.json
@@ -3,6 +3,24 @@
   "description": "Schema for commented point annotation.",
   "type": "object",
   "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_uuid": {
+      "title": " Uuid",
+      "description": "Universally unique ID",
+      "minLength": 1,
+      "type": "string"
+    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -30,6 +48,9 @@
     }
   },
   "required": [
+    "_api_version",
+    "_kind",
+    "_uuid",
     "annotation_id",
     "generation",
     "record_id",

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_point.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_point.json
@@ -15,12 +15,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "_uuid": {
-      "title": " Uuid",
-      "description": "Universally unique ID",
-      "minLength": 1,
-      "type": "string"
-    },
     "annotation_id": {
       "title": "Annotation Id",
       "minLength": 1,
@@ -43,6 +37,10 @@
       "title": "Timestamp To",
       "type": "number"
     },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
+    },
     "commented_point": {
       "$ref": "#/definitions/CommentedPoint"
     }
@@ -50,12 +48,12 @@
   "required": [
     "_api_version",
     "_kind",
-    "_uuid",
     "annotation_id",
     "generation",
     "record_id",
     "timestamp_from",
     "timestamp_to",
+    "created_at",
     "commented_point"
   ],
   "definitions": {

--- a/openapi/dataware-tools.com/v1alpha1/file.json
+++ b/openapi/dataware-tools.com/v1alpha1/file.json
@@ -3,6 +3,24 @@
   "description": "Schema for files.",
   "type": "object",
   "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_uuid": {
+      "title": " Uuid",
+      "description": "Universally unique ID",
+      "minLength": 1,
+      "type": "string"
+    },
     "description": {
       "title": "Description",
       "type": "string"
@@ -23,6 +41,9 @@
     }
   },
   "required": [
+    "_api_version",
+    "_kind",
+    "_uuid",
     "record_id",
     "path"
   ]

--- a/openapi/dataware-tools.com/v1alpha1/file.json
+++ b/openapi/dataware-tools.com/v1alpha1/file.json
@@ -15,12 +15,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "_uuid": {
-      "title": " Uuid",
-      "description": "Universally unique ID",
-      "minLength": 1,
-      "type": "string"
-    },
     "description": {
       "title": "Description",
       "type": "string"
@@ -43,7 +37,6 @@
   "required": [
     "_api_version",
     "_kind",
-    "_uuid",
     "record_id",
     "path"
   ]

--- a/openapi/dataware-tools.com/v1alpha1/record.json
+++ b/openapi/dataware-tools.com/v1alpha1/record.json
@@ -3,6 +3,24 @@
   "description": "Schema for records.",
   "type": "object",
   "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_uuid": {
+      "title": " Uuid",
+      "description": "Universally unique ID",
+      "minLength": 1,
+      "type": "string"
+    },
     "description": {
       "title": "Description",
       "type": "string"
@@ -14,6 +32,9 @@
     }
   },
   "required": [
+    "_api_version",
+    "_kind",
+    "_uuid",
     "record_id"
   ]
 }

--- a/openapi/dataware-tools.com/v1alpha1/record.json
+++ b/openapi/dataware-tools.com/v1alpha1/record.json
@@ -15,12 +15,6 @@
       "minLength": 1,
       "type": "string"
     },
-    "_uuid": {
-      "title": " Uuid",
-      "description": "Universally unique ID",
-      "minLength": 1,
-      "type": "string"
-    },
     "description": {
       "title": "Description",
       "type": "string"
@@ -34,7 +28,6 @@
   "required": [
     "_api_version",
     "_kind",
-    "_uuid",
     "record_id"
   ]
 }

--- a/pydtk/db/schemas/__init__.py
+++ b/pydtk/db/schemas/__init__.py
@@ -60,14 +60,20 @@ def register_schema(schema):
 class BaseSchema(BaseModel):
     """BaseSchema."""
 
-    _api_version: constr(min_length=1, strict=True) = Field(
-        ..., description="Schema version information."
+    api_version: constr(min_length=1, strict=True) = Field(
+        ...,
+        description="Schema version information.",
+        alias="_api_version",
     )
-    _kind: constr(min_length=1, strict=True) = Field(
-        ..., description="Kind of information"
+    kind: constr(min_length=1, strict=True) = Field(
+        ...,
+        description="Kind of information",
+        alias="_kind",
     )
-    _uuid: constr(min_length=1, strict=True) = Field(
-        ..., description="Universally unique ID"
+    uuid: constr(min_length=1, strict=True) = Field(
+        ...,
+        description="Universally unique ID",
+        alias="_uuid",
     )
     # TODO(d-hayashi): Add _created_at?
 
@@ -84,7 +90,9 @@ def get_schema(api_version: str, kind: str):
 
     """
     try:
-        schema = SCHEMAS_BY_VERSIONS[api_version.replace("/", os.sep).lower()][kind.lower()]
+        schema = SCHEMAS_BY_VERSIONS[api_version.replace("/", os.sep).lower()][
+            kind.lower()
+        ]
     except KeyError:
         raise SchemaNotFoundError()
     return schema

--- a/pydtk/db/schemas/__init__.py
+++ b/pydtk/db/schemas/__init__.py
@@ -70,12 +70,18 @@ class BaseSchema(BaseModel):
         description="Kind of information",
         alias="_kind",
     )
-    uuid: constr(min_length=1, strict=True) = Field(
-        ...,
-        description="Universally unique ID",
-        alias="_uuid",
-    )
-    # TODO(d-hayashi): Add _created_at?
+    # NOTE(kan-bayashi): `_uuid` and `_creation_time` will be created by pydtk
+    #   and therefore we do not validate them.
+    # uuid: constr(min_length=1, strict=True) = Field(
+    #     ...,
+    #     description="Universally unique ID",
+    #     alias="_uuid",
+    # )
+    # creation_time: int = Field(
+    #     ...,
+    #     description="Creation time",
+    #     alias="_creation_time",
+    # )
 
 
 def get_schema(api_version: str, kind: str):

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha1/annotation.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha1/annotation.py
@@ -15,3 +15,5 @@ class Annotation(BaseSchema):
     record_id: constr(min_length=1) = Field(..., description="")
     timestamp_from: float
     timestamp_to: float
+    # TODO(watanabe): String?
+    created_at: str

--- a/pydtk/db/v4/handlers/__init__.py
+++ b/pydtk/db/v4/handlers/__init__.py
@@ -592,16 +592,10 @@ class BaseDBHandler(object):
         """
         assert strategy in ['merge', 'overwrite'], 'Unknown strategy.'
 
-        # Validate data.
-        if '_api_version' in data_in.keys() and '_kind' in data_in.keys():
-            get_schema(data_in['_api_version'], data_in['_kind']).validate(data_in)
-        else:
-            self.logger.warning("`_api_version` or `_kind` are not defined. Validation is skipped.")
-
         data = deepcopy(data_in)
-        if '_uuid' not in data.keys() or '_creation_time' not in data.keys():
-            # Add _uuid and _creation_time
+        if '_uuid' not in data.keys():
             data['_uuid'] = self._get_uuid_from_item(data)
+        if '_creation_time' not in data.keys():
             data['_creation_time'] = datetime.now().timestamp()
 
         if data['_uuid'] in self._data.keys():
@@ -609,6 +603,12 @@ class BaseDBHandler(object):
                 base_data = self._data[data['_uuid']]
                 data = self._merger.merge(base_data, data)
             self._uuids_duplicated += [data['_uuid']]
+
+        # Validate data.
+        if '_api_version' in data.keys() and '_kind' in data.keys():
+            get_schema(data['_api_version'], data['_kind']).validate(data)
+        else:
+            self.logger.warning("`_api_version` or `_kind` are not defined. Validation is skipped.")
 
         # Add new columns (keys) to config
         columns = self._config['columns'] if 'columns' in self._config.keys() else []


### PR DESCRIPTION
## What?

- fix the case where the property starting with underscore is not validated.

## Why?

- property starting with underscore should be created with alias

## See also [Optional]
https://pydantic-docs.helpmanual.io/usage/schema/#:~:text=and%20default_factory.-,alias,-%3A%20the%20public%20name
