### PR TITLE
fix: drop the support of ubuntu 18.04 in docker-build ci

### DIFF
--- a/.github/workflows/build_and_deploy_document.yaml
+++ b/.github/workflows/build_and_deploy_document.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-deploy-document:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/build_and_publish_images.yml
+++ b/.github/workflows/build_and_publish_images.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-publish-images:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 300
     strategy:
       matrix:
@@ -18,8 +18,6 @@ jobs:
             'dev'
         ]
         image_target: [
-            "ubuntu-18.04",
-            "ubuntu-18.04-ros",
             "ubuntu-20.04",
             "ubuntu-20.04-ros"
         ]


### PR DESCRIPTION
## What?

- drop the support of ubuntu 18.04 in docker build ci

## Why?

- we support only ubuntu >= 20.04 
