### PR TITLE
fix: allow additional properties in Record and File

### DIFF
--- a/openapi/dataware-tools.com/v1alpha2/file.json
+++ b/openapi/dataware-tools.com/v1alpha2/file.json
@@ -1,0 +1,44 @@
+{
+  "title": "File",
+  "description": "Schema for files.",
+  "type": "object",
+  "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    },
+    "record_id": {
+      "title": "Record Id",
+      "minLength": 1,
+      "type": "string"
+    },
+    "path": {
+      "title": "Path",
+      "minLength": 1,
+      "type": "string"
+    },
+    "contents": {
+      "title": "Contents",
+      "type": "object"
+    }
+  },
+  "required": [
+    "_api_version",
+    "_kind",
+    "record_id",
+    "path"
+  ],
+  "additionalProperties": {}
+}

--- a/openapi/dataware-tools.com/v1alpha2/record.json
+++ b/openapi/dataware-tools.com/v1alpha2/record.json
@@ -1,0 +1,34 @@
+{
+  "title": "Record",
+  "description": "Schema for records.",
+  "type": "object",
+  "properties": {
+    "_api_version": {
+      "title": " Api Version",
+      "description": "Schema version information.",
+      "minLength": 1,
+      "type": "string"
+    },
+    "_kind": {
+      "title": " Kind",
+      "description": "Kind of information",
+      "minLength": 1,
+      "type": "string"
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    },
+    "record_id": {
+      "title": "Record Id",
+      "minLength": 1,
+      "type": "string"
+    }
+  },
+  "required": [
+    "_api_version",
+    "_kind",
+    "record_id"
+  ],
+  "additionalProperties": {}
+}

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha2/file.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha2/file.py
@@ -18,6 +18,8 @@ class File(BaseSchema):
 
     # Allow additional properties
     class Config:
+        """Config."""
+
         extra = Extra.allow
         schema_extra = {
             "additionalProperties": {}

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha2/file.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha2/file.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from pydantic import Field, constr, Extra
+
+from pydtk.db.schemas import BaseSchema, register_schema
+
+
+@register_schema
+class File(BaseSchema):
+    """Schema for files."""
+
+    _api_version = "dataware-tools.com/v1alpha2"
+    _kind = "File"
+    description: Optional[constr()] = Field(None, description="")
+    record_id: constr(min_length=1) = Field(..., description="")
+    path: constr(min_length=1) = Field(..., description="")
+    contents: Optional[dict] = Field(None, description="")
+
+    # Allow additional properties
+    class Config:
+        extra = Extra.allow
+        schema_extra = {
+            "additionalProperties": {}
+        }

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha2/record.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha2/record.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from pydantic import Field, constr, Extra
+
+from pydtk.db.schemas import BaseSchema, register_schema
+
+
+@register_schema
+class Record(BaseSchema):
+    """Schema for records."""
+
+    _api_version = "dataware-tools.com/v1alpha2"
+    _kind = "Record"
+    description: Optional[constr()] = Field(None, description="")
+    record_id: constr(min_length=1) = Field(..., description="")
+
+    # Allow additional properties
+    class Config:
+        extra = Extra.allow
+        schema_extra = {
+            "additionalProperties": {}
+        }

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha2/record.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha2/record.py
@@ -16,6 +16,8 @@ class Record(BaseSchema):
 
     # Allow additional properties
     class Config:
+        """Config."""
+
         extra = Extra.allow
         schema_extra = {
             "additionalProperties": {}


### PR DESCRIPTION
## What?
Add `"additionalProperties": {}` to OpenAPI spec files of Record and File models.

## Why?
To align with the existing data

## See also [Optional]
https://swagger.io/docs/specification/data-models/dictionaries/#:~:text=type%3A%20string-,Free%2DForm%20Objects,-If%20the%20dictionary
