### PR TITLE
fix: format of `$ref` in OpenAPI specifications

### DIFF
--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_pixel.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_pixel.json
@@ -42,7 +42,7 @@
       "type": "string"
     },
     "commented_image_pixel": {
-      "$ref": "#/definitions/CommentedImagePixel"
+      "$ref": "./definitions.json#/CommentedImagePixel"
     }
   },
   "required": [
@@ -99,7 +99,7 @@
           "type": "string"
         },
         "image_pixel": {
-          "$ref": "#/definitions/ImagePixel"
+          "$ref": "./definitions.json#/ImagePixel"
         }
       },
       "required": [

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_rectangular_area.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_image_rectangular_area.json
@@ -42,7 +42,7 @@
       "type": "string"
     },
     "commented_image_rectangular_area": {
-      "$ref": "#/definitions/CommentedImageRectangularArea"
+      "$ref": "./definitions.json#/CommentedImageRectangularArea"
     }
   },
   "required": [
@@ -109,7 +109,7 @@
           "type": "string"
         },
         "image_rectangular_area": {
-          "$ref": "#/definitions/ImageRectangularArea"
+          "$ref": "./definitions.json#/ImageRectangularArea"
         }
       },
       "required": [

--- a/openapi/dataware-tools.com/v1alpha1/annotation_commented_point.json
+++ b/openapi/dataware-tools.com/v1alpha1/annotation_commented_point.json
@@ -42,7 +42,7 @@
       "type": "string"
     },
     "commented_point": {
-      "$ref": "#/definitions/CommentedPoint"
+      "$ref": "./definitions.json#/CommentedPoint"
     }
   },
   "required": [
@@ -98,7 +98,7 @@
           "type": "string"
         },
         "point": {
-          "$ref": "#/definitions/Point"
+          "$ref": "./definitions.json#/Point"
         }
       },
       "required": [

--- a/pydtk/bin/oas.py
+++ b/pydtk/bin/oas.py
@@ -47,7 +47,7 @@ class OpenAPISpecification(object):
             f.write(oas)
 
     def _schema_to_oas(self, schema: BaseSchema):
-        return schema.schema_json(indent=2)
+        return schema.schema_json(indent=2, ref_template='./definitions.json#/{model}')
 
 
 def dump_oas(out_dir: str) -> None:


### PR DESCRIPTION
## What?
Fix format of `$ref` value from `#/definitions/{model}` to `./definitions.json#/{model}`

## Why?
To avoid errors when generating API clients

