### PR TITLE
fix: fix wrong name entry in default config

### DIFF
--- a/pydtk/conf/v4.yaml
+++ b/pydtk/conf/v4.yaml
@@ -37,7 +37,7 @@ db:
       username: ""
       password: ""
       database: ""
-    annotations:
+    annotation:
       engine: tinymongo
       host: /tmp/pydtk-annotations
       username: ""

--- a/pydtk/db/v4/handlers/annotation.py
+++ b/pydtk/db/v4/handlers/annotation.py
@@ -16,7 +16,7 @@ class AnnotationDBHandler(_BaseDBHandler):
     """Handler for annotations."""
 
     __version__ = "v4"
-    db_defaults = load_config(__version__).db.connection.annotations
+    db_defaults = load_config(__version__).db.connection.annotation
     _df_class = "annotation_df"
     _database_id: str = ""
 


### PR DESCRIPTION
## What?

- fix default name entry in default config

## Why?

- To use `db_class` as the default config entry name

