### PR TITLE
ci: bump poetry and python in publish-to-pypi workflow

### DIFF
--- a/.github/workflows/on_release.yaml
+++ b/.github/workflows/on_release.yaml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         # python-version: [3.6, 3.7, 3.8, 3.9]
-        python-version: [3.7]
-        poetry-version: [1.1.15]
+        python-version: [3.9]
+        poetry-version: [1.5.0]
         # os: [ubuntu-latest, macos-latest, windows-latest]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## What?
Bump poetry to v1.5.0 in CI that publishes packages to PyPI.

## Why?
The current version is out of date and no longer works properly.

## See also [Optional]
Failed job: https://github.com/dataware-tools/pydtk/actions/runs/5122883529/jobs/9212593438