### PR TITLE
fix: separate file of arbitrary-annotation

### DIFF
--- a/pydtk/db/schemas/dataware-tools.com/v1alpha5/annotation.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha5/annotation.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from pydantic import Extra, Field, constr
+from pydantic import Field, constr
 
 from pydtk.db.schemas import BaseSchema, register_schema
 
@@ -18,16 +18,3 @@ class Annotation(BaseSchema):
     timestamp_to: Union[float, None]
     created_at: Union[float, None]
     created_by: Union[str, None]
-
-
-@register_schema
-class ArbitraryAnnotation(Annotation):
-    """Schema for an annotation with extra fields."""
-
-    _api_version = "dataware-tools.com/v1alpha5"
-    _kind = "ArbitraryAnnotation"
-
-    class Config:
-        """Configs for ArbitraryAnnotation."""
-
-        extra = Extra.allow

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha5/arbitrary_annotation.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha5/arbitrary_annotation.py
@@ -1,0 +1,21 @@
+import os
+
+from pydantic import Extra
+
+from pydtk.db.schemas import register_schema
+from pydtk.utils.imports import import_module_from_path
+
+annotation = import_module_from_path(f"{os.path.dirname(__file__)}/annotation.py")
+
+
+@register_schema
+class ArbitraryAnnotation(annotation.Annotation):
+    """Schema for an annotation with extra fields."""
+
+    _api_version = "dataware-tools.com/v1alpha5"
+    _kind = "ArbitraryAnnotation"
+
+    class Config:
+        """Configs for ArbitraryAnnotation."""
+
+        extra = Extra.allow


### PR DESCRIPTION
## What?
Move ArbitraryAnnotation class to a separated file

## Why?
To generate OpenAPI specifications properly

## See also [Optional]
#156 
