### PR TITLE
fix: add schema_extra to arbitrary-annotation

### DIFF
--- a/pydtk/db/schemas/dataware-tools.com/v1alpha5/arbitrary_annotation.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha5/arbitrary_annotation.py
@@ -1,8 +1,9 @@
 import os
+from typing import Any, Dict, Type
 
 from pydantic import Extra
 
-from pydtk.db.schemas import register_schema
+from pydtk.db.schemas import BaseSchema, register_schema
 from pydtk.utils.imports import import_module_from_path
 
 annotation = import_module_from_path(f"{os.path.dirname(__file__)}/annotation.py")
@@ -19,3 +20,9 @@ class ArbitraryAnnotation(annotation.Annotation):
         """Configs for ArbitraryAnnotation."""
 
         extra = Extra.allow
+
+        @staticmethod
+        def schema_extra(schema: Dict[str, Any], model: Type["ArbitraryAnnotation"]):
+            """Extra schema."""
+            BaseSchema.Config.schema_extra(schema, model)
+            schema["additionalProperties"] = {}


### PR DESCRIPTION
## What?
Fix schema ArbitraryAnnotation

## Why?
To generate OpenAPI specifications properly

