### PR TITLE
feat: add start and end timestamp to meta db config

### DIFF
--- a/pydtk/conf/v4.yaml
+++ b/pydtk/conf/v4.yaml
@@ -79,6 +79,14 @@ db:
           dtype: dict
           aggregation: mergeObjects
           display_name: Contents
+        - name: start_timestamp
+          dtype: float
+          aggregation: min
+          display_name: Start timestamp
+        - name: end_timestamp
+          dtype: float
+          aggregation: max
+          display_name: End timestamp
       index_columns:
         - _kind
         - record_id


### PR DESCRIPTION
## What?

Add start_timestamp and end_timestamp fields with min and max aggregation to meta db configuration.

## Why?

To derive the start and end timestamp of a record.
