### PR TITLE
feat: remove _api_version and _kind from required fields

### DIFF
--- a/pydtk/db/schemas/__init__.py
+++ b/pydtk/db/schemas/__init__.py
@@ -61,12 +61,12 @@ class BaseSchema(BaseModel):
     """BaseSchema."""
 
     api_version: Optional[constr(min_length=1, strict=True)] = Field(
-        ...,
+        None,
         description="Schema version information.",
         alias="_api_version",
     )
     kind: Optional[constr(min_length=1, strict=True)] = Field(
-        ...,
+        None,
         description="Kind of information",
         alias="_kind",
     )


### PR DESCRIPTION
## What?

Remove _api_version and _kind from required fields.

## Why?

To solve error on validating api response when _kind or _api_version is absent.
