### PR TITLE
feat: add optional property to AnnotationCommentedImageRectanglerArea

### DIFF
--- a/pydtk/db/schemas/dataware-tools.com/v1alpha2/annotation_commented_image_rectangular_area.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha2/annotation_commented_image_rectangular_area.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from pydantic import BaseModel, Field, constr
 
@@ -27,6 +28,7 @@ class CommentedImageRectangularArea(BaseModel):
     frame_id: constr(min_length=0) = Field(..., description="Cordinate ID.")
     target_topic: constr(min_length=1) = Field(..., description="Target topic to comment.")
     image_rectangular_area: ImageRectangularArea
+    instance_id: Optional[constr()] = Field(None, description="ID for tracking target instance.")
 
 
 @register_schema

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha2/annotation_commented_image_rectangular_area.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha2/annotation_commented_image_rectangular_area.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 
 from pydantic import BaseModel, Field, constr
 
@@ -28,7 +27,6 @@ class CommentedImageRectangularArea(BaseModel):
     frame_id: constr(min_length=0) = Field(..., description="Cordinate ID.")
     target_topic: constr(min_length=1) = Field(..., description="Target topic to comment.")
     image_rectangular_area: ImageRectangularArea
-    instance_id: Optional[constr()] = Field(None, description="ID for tracking target instance.")
 
 
 @register_schema

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha5/annotation_commented_image_pixel.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha5/annotation_commented_image_pixel.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from pydantic import BaseModel, Field, constr
 
@@ -23,6 +24,7 @@ class CommentedImagePixel(BaseModel):
     frame_id: constr(min_length=0) = Field(..., description="Cordinate ID.")
     target_topic: constr(min_length=1) = Field(..., description="Target topic to comment.")
     image_pixel: ImagePixel
+    instance_id: Optional[constr()] = Field(None, description="ID for tracking target instance.")
 
 
 @register_schema

--- a/pydtk/db/schemas/dataware-tools.com/v1alpha5/annotation_commented_image_rectangular_area.py
+++ b/pydtk/db/schemas/dataware-tools.com/v1alpha5/annotation_commented_image_rectangular_area.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from pydantic import BaseModel, Field, constr
 
@@ -26,6 +27,7 @@ class CommentedImageRectangularArea(BaseModel):
     frame_id: constr(min_length=0) = Field(..., description="Cordinate ID.")
     target_topic: constr(min_length=1) = Field(..., description="Target topic to comment.")
     image_rectangular_area: ImageRectangularArea
+    instance_id: Optional[constr()] = Field(None, description="ID for tracking target instance.")
 
 
 @register_schema


### PR DESCRIPTION
## What?
- add optional property (instance id) to AnnotationCommentedImageRectanglerArea 

## Why?
- To track annotated instance 

## See also
https://www.notion.so/humandatawarelab/scene-viewer-943bb4841bb44aa7b1751ae5d41629a6?pvs=4